### PR TITLE
Canopy as swift-dependencies dependency.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,10 @@ let package = Package(
     .package(
       url: "https://github.com/groue/Semaphore",
       from: "0.0.6"
+    ),
+    .package(
+      url: "https://github.com/pointfreeco/swift-dependencies",
+      from: "0.2.0"
     )
   ],
   targets: [
@@ -24,7 +28,11 @@ let package = Package(
     // Targets can depend on other targets in this package, and on products in packages this package depends on.
     .target(
       name: "Canopy",
-      dependencies: ["Semaphore", "CanopyTypes"],
+      dependencies: [
+        "Semaphore",
+        "CanopyTypes",
+        .product(name: "Dependencies", package: "swift-dependencies")
+      ],
       path: "Targets/Canopy/Sources"
       // https://danielsaidi.com/blog/2022/05/18/how-to-suppress-linking-warning
       // Canopy by default gives a warning about unsafe code for application extensions. Not sure why it says that.

--- a/Targets/Canopy/Sources/Dependency/Canopy+Dependency.swift
+++ b/Targets/Canopy/Sources/Dependency/Canopy+Dependency.swift
@@ -1,0 +1,15 @@
+import Dependencies
+
+private enum CanopyKey: DependencyKey {
+  static let liveValue: CanopyType = Canopy()
+  static let testValue: CanopyType = MockCanopy()
+  static let previewValue: CanopyType = MockCanopy()
+}
+
+extension DependencyValues {
+  /// Canopy packaged as CloudKit dependency via swift-dependencies.
+  public var cloudKit: CanopyType {
+    get { self[CanopyKey.self] }
+    set { self[CanopyKey.self] = newValue }
+  }
+}

--- a/Targets/Canopy/Tests/DependencyTests.swift
+++ b/Targets/Canopy/Tests/DependencyTests.swift
@@ -1,0 +1,51 @@
+import Canopy
+import CanopyTestTools
+import CloudKit
+import Dependencies
+import XCTest
+
+final class DependencyTests: XCTestCase {
+  struct Fetcher {
+    @Dependency(\.cloudKit) var canopy
+    func fetchRecord(recordID: CKRecord.ID) async -> CKRecord? {
+      return try! await canopy.databaseAPI(usingDatabaseScope: .private).fetchRecords(
+        with: [recordID],
+        desiredKeys: nil,
+        perRecordIDProgressBlock: nil,
+        qualityOfService: .default
+      ).get().foundRecords.first
+    }
+  }
+  
+  func test_dependency() async {
+    let fetcher = withDependencies {
+      let testRecordID = CKRecord.ID(recordName: "testRecordID")
+      let testRecord = CKRecord(recordType: "TestRecord", recordID: testRecordID)
+      testRecord["testKey"] = "testValue"
+      $0.cloudKit = MockCanopy(
+        mockPrivateDatabase: MockDatabase(
+          operationResults: [
+            .fetch(
+              .init(
+                fetchRecordResults: [
+                  .init(
+                    recordID: testRecordID,
+                    result: .success(testRecord)
+                  )
+                ],
+                fetchResult: .init(
+                  result: .success(())
+                )
+              )
+            )
+          ],
+          scope: .private
+        )
+      )
+    } operation: {
+      Fetcher()
+    }
+    let record = await fetcher.fetchRecord(recordID: .init(recordName: "testRecordID"))!
+    XCTAssertEqual(record["testKey"], "testValue")
+  }
+}


### PR DESCRIPTION
Provides Canopy as `cloudKit` dependency via swift-dependencies.