### PR TITLE
Renamed mocks to CKReplayingMock*

### DIFF
--- a/Targets/Canopy/Tests/CanopyTests.swift
+++ b/Targets/Canopy/Tests/CanopyTests.swift
@@ -6,10 +6,10 @@ import XCTest
 final class CanopyTests: XCTestCase {
   func test_init_with_default_settings() async {
     let _ = Canopy(
-      container: MockCKContainer(),
-      publicCloudDatabase: MockDatabase(),
-      privateCloudDatabase: MockDatabase(),
-      sharedCloudDatabase: MockDatabase(),
+      container: ReplayingMockCKContainer(),
+      publicCloudDatabase: ReplayingMockCKDatabase(),
+      privateCloudDatabase: ReplayingMockCKDatabase(),
+      sharedCloudDatabase: ReplayingMockCKDatabase(),
       tokenStore: TestTokenStore()
     )
   }
@@ -29,9 +29,9 @@ final class CanopyTests: XCTestCase {
     var modifiableSettings = ModifiableSettings()
     
     let canopy = Canopy(
-      container: MockCKContainer(),
-      publicCloudDatabase: MockDatabase(),
-      privateCloudDatabase: MockDatabase(
+      container: ReplayingMockCKContainer(),
+      publicCloudDatabase: ReplayingMockCKDatabase(),
+      privateCloudDatabase: ReplayingMockCKDatabase(
         operationResults: [
           .modify(
             .init(
@@ -51,7 +51,7 @@ final class CanopyTests: XCTestCase {
           )
         ]
       ),
-      sharedCloudDatabase: MockDatabase(),
+      sharedCloudDatabase: ReplayingMockCKDatabase(),
       settings: { modifiableSettings },
       tokenStore: TestTokenStore()
     )
@@ -75,10 +75,10 @@ final class CanopyTests: XCTestCase {
   
   func test_returns_same_api_instances() async {
     let canopy = Canopy(
-      container: MockCKContainer(),
-      publicCloudDatabase: MockDatabase(),
-      privateCloudDatabase: MockDatabase(),
-      sharedCloudDatabase: MockDatabase()
+      container: ReplayingMockCKContainer(),
+      publicCloudDatabase: ReplayingMockCKDatabase(),
+      privateCloudDatabase: ReplayingMockCKDatabase(),
+      sharedCloudDatabase: ReplayingMockCKDatabase()
     )
     
     let privateApi1 = await canopy.databaseAPI(usingDatabaseScope: .private) as! CKDatabaseAPI

--- a/Targets/Canopy/Tests/ContainerAPITests.swift
+++ b/Targets/Canopy/Tests/ContainerAPITests.swift
@@ -8,7 +8,7 @@ import XCTest
 final class ContainerAPITests: XCTestCase {
   func test_userRecordID_success() async {
     let recordID = CKRecord.ID(recordName: "SomeUserID")
-    let container = MockCKContainer(
+    let container = ReplayingMockCKContainer(
       operationResults: [
         .userRecordID(
           .init(
@@ -25,7 +25,7 @@ final class ContainerAPITests: XCTestCase {
   
   func test_userRecordID_failure() async {
     let ckError = CKError(CKError.Code.networkUnavailable)
-    let container = MockCKContainer(
+    let container = ReplayingMockCKContainer(
       operationResults: [
         .userRecordID(.init(userRecordID: nil, error: ckError))
       ]
@@ -39,7 +39,7 @@ final class ContainerAPITests: XCTestCase {
   }
   
   func test_accountStatus_success() async {
-    let container = MockCKContainer(
+    let container = ReplayingMockCKContainer(
       operationResults: [
         .accountStatus(.init(status: .available, error: nil))
       ]
@@ -50,7 +50,7 @@ final class ContainerAPITests: XCTestCase {
   }
   
   func test_accountStatus_success_multiple_requests() async {
-    let container = MockCKContainer(
+    let container = ReplayingMockCKContainer(
       operationResults: [
         .accountStatus(.init(status: .available, error: nil))
       ]
@@ -69,7 +69,7 @@ final class ContainerAPITests: XCTestCase {
   }
   
   func test_accountStatus_failure() async {
-    let container = MockCKContainer(
+    let container = ReplayingMockCKContainer(
       operationResults: [
         .accountStatus(
           .init(
@@ -88,7 +88,7 @@ final class ContainerAPITests: XCTestCase {
   }
   
   func test_accountStatus_stream() async {
-    let container = MockCKContainer(
+    let container = ReplayingMockCKContainer(
       operationResults: [
         .accountStatus(.init(status: .available, error: nil)),
         .accountStatus(.init(status: .noAccount, error: nil)),
@@ -108,7 +108,7 @@ final class ContainerAPITests: XCTestCase {
   }
   
   func test_accountStatus_twoStreams() async {
-    let container = MockCKContainer(
+    let container = ReplayingMockCKContainer(
       operationResults: [
         .accountStatus(.init(status: .available, error: nil)),
         .accountStatus(.init(status: .noAccount, error: nil)),
@@ -141,7 +141,7 @@ final class ContainerAPITests: XCTestCase {
     let lookupInfo1 = CKUserIdentity.LookupInfo(emailAddress: "email@example.com")
     let lookupInfo2 = CKUserIdentity.LookupInfo(emailAddress: "email2@example.com")
 
-    let mockContainer = MockCKContainer(
+    let mockContainer = ReplayingMockCKContainer(
       operationResults: [
         .fetchShareParticipants(
           .init(
@@ -170,7 +170,7 @@ final class ContainerAPITests: XCTestCase {
     let lookupInfo1 = CKUserIdentity.LookupInfo(emailAddress: "email@example.com")
     let lookupInfo2 = CKUserIdentity.LookupInfo(emailAddress: "email2@example.com")
 
-    let mockContainer = MockCKContainer(
+    let mockContainer = ReplayingMockCKContainer(
       operationResults: [
         .fetchShareParticipants(
           .init(
@@ -202,7 +202,7 @@ final class ContainerAPITests: XCTestCase {
     let lookupInfo1 = CKUserIdentity.LookupInfo(emailAddress: "email@example.com")
     let lookupInfo2 = CKUserIdentity.LookupInfo(emailAddress: "email2@example.com")
 
-    let mockContainer = MockCKContainer(
+    let mockContainer = ReplayingMockCKContainer(
       operationResults: [
         .fetchShareParticipants(
           .init(
@@ -231,7 +231,7 @@ final class ContainerAPITests: XCTestCase {
   }
   
   func test_accept_shares_success() async {
-    let mockContainer = MockCKContainer(
+    let mockContainer = ReplayingMockCKContainer(
       operationResults: [
         .acceptShares(
           .init(
@@ -253,7 +253,7 @@ final class ContainerAPITests: XCTestCase {
   }
   
   func test_accept_shares_record_failure() async {
-    let mockContainer = MockCKContainer(
+    let mockContainer = ReplayingMockCKContainer(
       operationResults: [
         .acceptShares(
           .init(
@@ -278,7 +278,7 @@ final class ContainerAPITests: XCTestCase {
   }
   
   func test_accept_shares_result_failure() async {
-    let mockContainer = MockCKContainer(
+    let mockContainer = ReplayingMockCKContainer(
       operationResults: [
         .acceptShares(
           .init(

--- a/Targets/Canopy/Tests/DatabaseAPITests.swift
+++ b/Targets/Canopy/Tests/DatabaseAPITests.swift
@@ -14,7 +14,7 @@ final class DatabaseAPITests: XCTestCase {
   }
   
   func test_init_with_default_settings() async {
-    let databaseAPI = CKDatabaseAPI(MockDatabase(), tokenStore: TestTokenStore())
+    let databaseAPI = CKDatabaseAPI(ReplayingMockCKDatabase(), tokenStore: TestTokenStore())
     let fetchDatabaseChangesBehavior = await databaseAPI.settingsProvider().fetchDatabaseChangesBehavior
     XCTAssertEqual(fetchDatabaseChangesBehavior, .regular(nil))
   }
@@ -22,7 +22,7 @@ final class DatabaseAPITests: XCTestCase {
   func test_query_records() async {
     let recordID = CKRecord.ID(recordName: "TestRecordName")
     let record = CKRecord(recordType: "TestRecord", recordID: recordID)
-    let db = MockDatabase(
+    let db = ReplayingMockCKDatabase(
       operationResults: [
         .query(
           .init(
@@ -48,7 +48,7 @@ final class DatabaseAPITests: XCTestCase {
   func test_delete_records_success() async {
     let recordID = CKRecord.ID(recordName: "TestRecordName")
     let record = CKRecord(recordType: "TestRecord", recordID: recordID)
-    let db = MockDatabase(
+    let db = ReplayingMockCKDatabase(
       operationResults: [
         .query(
           .init(
@@ -82,7 +82,7 @@ final class DatabaseAPITests: XCTestCase {
   func test_delete_records_query_failure() async {
     let recordID = CKRecord.ID(recordName: "TestRecordName")
     let record = CKRecord(recordType: "TestRecord", recordID: recordID)
-    let db = MockDatabase(
+    let db = ReplayingMockCKDatabase(
       operationResults: [
         .query(
           .init(
@@ -110,7 +110,7 @@ final class DatabaseAPITests: XCTestCase {
   func test_delete_records_empty_success() async {
     // When there are no records returned by query,
     // the deletion should still report a success, since there is no work to be done.
-    let db = MockDatabase(
+    let db = ReplayingMockCKDatabase(
       operationResults: [
         .query(
           .init(
@@ -130,7 +130,7 @@ final class DatabaseAPITests: XCTestCase {
   func test_fetch_records_success() async {
     let recordID = CKRecord.ID(recordName: "testRecord")
     let record = CKRecord(recordType: "TestRecord", recordID: recordID)
-    let db = MockDatabase(operationResults: [
+    let db = ReplayingMockCKDatabase(operationResults: [
       .fetch(
         .init(
           fetchRecordResults: [
@@ -147,7 +147,7 @@ final class DatabaseAPITests: XCTestCase {
   
   func test_fetch_records_record_failure() async {
     let recordID = CKRecord.ID(recordName: "testRecord")
-    let db = MockDatabase(operationResults: [
+    let db = ReplayingMockCKDatabase(operationResults: [
       .fetch(
         .init(
           fetchRecordResults: [
@@ -168,7 +168,7 @@ final class DatabaseAPITests: XCTestCase {
   func test_fetch_records_result_failure() async {
     let recordID = CKRecord.ID(recordName: "testRecord")
     let record = CKRecord(recordType: "TestRecord", recordID: recordID)
-    let db = MockDatabase(operationResults: [
+    let db = ReplayingMockCKDatabase(operationResults: [
       .fetch(
         .init(
           fetchRecordResults: [
@@ -190,7 +190,7 @@ final class DatabaseAPITests: XCTestCase {
     let recordID = CKRecord.ID(recordName: "testRecord")
     let recordID2 = CKRecord.ID(recordName: "testRecord2")
     let record = CKRecord(recordType: "TestRecord", recordID: recordID)
-    let db = MockDatabase(operationResults: [
+    let db = ReplayingMockCKDatabase(operationResults: [
       .fetch(
         .init(
           fetchRecordResults: [
@@ -210,7 +210,7 @@ final class DatabaseAPITests: XCTestCase {
   func test_modify_zones_success() async {
     let zoneToSave = CKRecordZone(zoneID: .init(zoneName: "SomeZone"))
     let zoneIDToDelete = CKRecordZone.ID(zoneName: "ZoneToDelete")
-    let db = MockDatabase(operationResults: [
+    let db = ReplayingMockCKDatabase(operationResults: [
       .modifyZones(
         .init(
           savedZoneResults: [
@@ -232,7 +232,7 @@ final class DatabaseAPITests: XCTestCase {
   func test_modify_zones_save_failure() async {
     let zoneToSave = CKRecordZone(zoneID: .init(zoneName: "SomeZone"))
     let zoneIDToDelete = CKRecordZone.ID(zoneName: "ZoneToDelete")
-    let db = MockDatabase(operationResults: [
+    let db = ReplayingMockCKDatabase(operationResults: [
       .modifyZones(
         .init(
           savedZoneResults: [
@@ -256,7 +256,7 @@ final class DatabaseAPITests: XCTestCase {
   func test_modify_zones_delete_failure() async {
     let zoneToSave = CKRecordZone(zoneID: .init(zoneName: "SomeZone"))
     let zoneIDToDelete = CKRecordZone.ID(zoneName: "ZoneToDelete")
-    let db = MockDatabase(operationResults: [
+    let db = ReplayingMockCKDatabase(operationResults: [
       .modifyZones(
         .init(
           savedZoneResults: [
@@ -280,7 +280,7 @@ final class DatabaseAPITests: XCTestCase {
   func test_modify_zones_operation_failure() async {
     let zoneToSave = CKRecordZone(zoneID: .init(zoneName: "SomeZone"))
     let zoneIDToDelete = CKRecordZone.ID(zoneName: "ZoneToDelete")
-    let db = MockDatabase(operationResults: [
+    let db = ReplayingMockCKDatabase(operationResults: [
       .modifyZones(
         .init(
           savedZoneResults: [
@@ -303,7 +303,7 @@ final class DatabaseAPITests: XCTestCase {
   
   func test_fetch_zones_success() async {
     let mockZone = CKRecordZone(zoneID: .init(zoneName: "MockZone", ownerName: CKCurrentUserDefaultName))
-    let db = MockDatabase(operationResults: [
+    let db = ReplayingMockCKDatabase(operationResults: [
       .fetchZones(
         .init(
           fetchZoneResults: [
@@ -320,7 +320,7 @@ final class DatabaseAPITests: XCTestCase {
   
   func test_fetch_zones_one_failure() async {
     let mockZone = CKRecordZone(zoneID: .init(zoneName: "MockZone", ownerName: CKCurrentUserDefaultName))
-    let db = MockDatabase(operationResults: [
+    let db = ReplayingMockCKDatabase(operationResults: [
       .fetchZones(
         .init(
           fetchZoneResults: [
@@ -340,7 +340,7 @@ final class DatabaseAPITests: XCTestCase {
   
   func test_fetch_zones_result_failure() async {
     let mockZone = CKRecordZone(zoneID: .init(zoneName: "MockZone", ownerName: CKCurrentUserDefaultName))
-    let db = MockDatabase(operationResults: [
+    let db = ReplayingMockCKDatabase(operationResults: [
       .fetchZones(
         .init(
           fetchZoneResults: [
@@ -362,7 +362,7 @@ final class DatabaseAPITests: XCTestCase {
     let subscriptionID = CKSubscription.ID("DBSubscription")
     let subscriptionIDToDelete = CKSubscription.ID("DBSubscriptionToDelete")
     let subscription = CKDatabaseSubscription(subscriptionID: subscriptionID)
-    let db = MockDatabase(
+    let db = ReplayingMockCKDatabase(
       operationResults: [
         .modifySubscriptions(
           .init(
@@ -386,7 +386,7 @@ final class DatabaseAPITests: XCTestCase {
     let subscriptionID = CKSubscription.ID("DBSubscription")
     let subscriptionIDToDelete = CKSubscription.ID("DBSubscriptionToDelete")
     let subscription = CKDatabaseSubscription(subscriptionID: subscriptionID)
-    let db = MockDatabase(
+    let db = ReplayingMockCKDatabase(
       operationResults: [
         .modifySubscriptions(
           .init(
@@ -413,7 +413,7 @@ final class DatabaseAPITests: XCTestCase {
     let subscriptionID = CKSubscription.ID("DBSubscription")
     let subscriptionIDToDelete = CKSubscription.ID("DBSubscriptionToDelete")
     let subscription = CKDatabaseSubscription(subscriptionID: subscriptionID)
-    let db = MockDatabase(
+    let db = ReplayingMockCKDatabase(
       operationResults: [
         .modifySubscriptions(
           .init(
@@ -440,7 +440,7 @@ final class DatabaseAPITests: XCTestCase {
     let subscriptionID = CKSubscription.ID("DBSubscription")
     let subscriptionIDToDelete = CKSubscription.ID("DBSubscriptionToDelete")
     let subscription = CKDatabaseSubscription(subscriptionID: subscriptionID)
-    let db = MockDatabase(
+    let db = ReplayingMockCKDatabase(
       operationResults: [
         .modifySubscriptions(
           .init(

--- a/Targets/Canopy/Tests/DependencyTests.swift
+++ b/Targets/Canopy/Tests/DependencyTests.swift
@@ -23,7 +23,7 @@ final class DependencyTests: XCTestCase {
       let testRecord = CKRecord(recordType: "TestRecord", recordID: testRecordID)
       testRecord["testKey"] = "testValue"
       $0.cloudKit = MockCanopy(
-        mockPrivateDatabase: MockDatabase(
+        mockPrivateDatabase: ReplayingMockCKDatabase(
           operationResults: [
             .fetch(
               .init(

--- a/Targets/Canopy/Tests/FetchDatabaseChangesTests.swift
+++ b/Targets/Canopy/Tests/FetchDatabaseChangesTests.swift
@@ -11,7 +11,7 @@ final class FetchDatabaseChangesTests: XCTestCase {
     let changedRecordZoneID2 = CKRecordZone.ID(zoneName: "changedZone2", ownerName: CKCurrentUserDefaultName)
     let deletedRecordZoneID = CKRecordZone.ID(zoneName: "deletedZone", ownerName: CKCurrentUserDefaultName)
     let purgedRecordZoneID = CKRecordZone.ID(zoneName: "purgedZone", ownerName: CKCurrentUserDefaultName)
-    let db = MockDatabase(operationResults: [
+    let db = ReplayingMockCKDatabase(operationResults: [
       .fetchDatabaseChanges(
         .init(
           changedRecordZoneIDs: [changedRecordZoneID1, changedRecordZoneID2],
@@ -34,7 +34,7 @@ final class FetchDatabaseChangesTests: XCTestCase {
   }
   
   func test_token_expired_error() async {
-    let db = MockDatabase(operationResults: [
+    let db = ReplayingMockCKDatabase(operationResults: [
       .fetchDatabaseChanges(
         .init(
           changedRecordZoneIDs: [],
@@ -55,7 +55,7 @@ final class FetchDatabaseChangesTests: XCTestCase {
   }
   
   func test_other_error() async {
-    let db = MockDatabase(operationResults: [
+    let db = ReplayingMockCKDatabase(operationResults: [
       .fetchDatabaseChanges(
         .init(
           changedRecordZoneIDs: [],
@@ -77,7 +77,7 @@ final class FetchDatabaseChangesTests: XCTestCase {
   
   func test_success_with_delay() async {
     let changedRecordZoneID1 = CKRecordZone.ID(zoneName: "changedZone1", ownerName: CKCurrentUserDefaultName)
-    let db = MockDatabase(operationResults: [
+    let db = ReplayingMockCKDatabase(operationResults: [
       .fetchDatabaseChanges(
         .init(
           changedRecordZoneIDs: [changedRecordZoneID1],
@@ -101,7 +101,7 @@ final class FetchDatabaseChangesTests: XCTestCase {
   
   func test_simulated_fail() async {
     let changedRecordZoneID1 = CKRecordZone.ID(zoneName: "changedZone1", ownerName: CKCurrentUserDefaultName)
-    let db = MockDatabase(operationResults: [
+    let db = ReplayingMockCKDatabase(operationResults: [
       .fetchDatabaseChanges(
         .init(
           changedRecordZoneIDs: [changedRecordZoneID1],
@@ -129,7 +129,7 @@ final class FetchDatabaseChangesTests: XCTestCase {
   
   func test_simulated_fail_with_delay() async {
     let changedRecordZoneID1 = CKRecordZone.ID(zoneName: "changedZone1", ownerName: CKCurrentUserDefaultName)
-    let db = MockDatabase(operationResults: [
+    let db = ReplayingMockCKDatabase(operationResults: [
       .fetchDatabaseChanges(
         .init(
           changedRecordZoneIDs: [changedRecordZoneID1],

--- a/Targets/Canopy/Tests/FetchZoneChangesTests.swift
+++ b/Targets/Canopy/Tests/FetchZoneChangesTests.swift
@@ -13,7 +13,7 @@ final class FetchZoneChangesTests: XCTestCase {
     let changedRecord = CKRecord(recordType: "TestRecord", recordID: changedRecordID)
     let zoneID = CKRecordZone.ID(zoneName: "testZone", ownerName: CKCurrentUserDefaultName)
     
-    let db = MockDatabase(operationResults: [
+    let db = ReplayingMockCKDatabase(operationResults: [
       .fetchZoneChanges(
         .init(
           recordWasChangedInZoneResults: [
@@ -53,7 +53,7 @@ final class FetchZoneChangesTests: XCTestCase {
     let changedRecord = CKRecord(recordType: "TestRecord", recordID: changedRecordID)
     let zoneID = CKRecordZone.ID(zoneName: "testZone", ownerName: CKCurrentUserDefaultName)
     
-    let db = MockDatabase(operationResults: [
+    let db = ReplayingMockCKDatabase(operationResults: [
       .fetchZoneChanges(
         .init(
           recordWasChangedInZoneResults: [
@@ -93,7 +93,7 @@ final class FetchZoneChangesTests: XCTestCase {
     let deletedRecordID = CKRecord.ID(recordName: "DeletedRecordID")
     let zoneID = CKRecordZone.ID(zoneName: "testZone", ownerName: CKCurrentUserDefaultName)
     
-    let db = MockDatabase(operationResults: [
+    let db = ReplayingMockCKDatabase(operationResults: [
       .fetchZoneChanges(
         .init(
           recordWasChangedInZoneResults: [
@@ -136,7 +136,7 @@ final class FetchZoneChangesTests: XCTestCase {
     let zoneID1 = CKRecordZone.ID(zoneName: "testZone1", ownerName: CKCurrentUserDefaultName)
     let zoneID2 = CKRecordZone.ID(zoneName: "testZone2", ownerName: CKCurrentUserDefaultName)
 
-    let db = MockDatabase(operationResults: [
+    let db = ReplayingMockCKDatabase(operationResults: [
       .fetchZoneChanges(
         .init(
           recordWasChangedInZoneResults: [],
@@ -176,7 +176,7 @@ final class FetchZoneChangesTests: XCTestCase {
     
     let zoneID = CKRecordZone.ID(zoneName: "testZone", ownerName: CKCurrentUserDefaultName)
     
-    let db = MockDatabase(operationResults: [
+    let db = ReplayingMockCKDatabase(operationResults: [
       .fetchZoneChanges(
         .init(
           recordWasChangedInZoneResults: [],
@@ -217,7 +217,7 @@ final class FetchZoneChangesTests: XCTestCase {
     let changedRecord = CKRecord(recordType: "TestRecord", recordID: changedRecordID)
     let zoneID = CKRecordZone.ID(zoneName: "testZone", ownerName: CKCurrentUserDefaultName)
     
-    let db = MockDatabase(operationResults: [
+    let db = ReplayingMockCKDatabase(operationResults: [
       .fetchZoneChanges(
         .init(
           recordWasChangedInZoneResults: [
@@ -256,7 +256,7 @@ final class FetchZoneChangesTests: XCTestCase {
     let changedRecord = CKRecord(recordType: "TestRecord", recordID: changedRecordID)
     let zoneID = CKRecordZone.ID(zoneName: "testZone", ownerName: CKCurrentUserDefaultName)
     
-    let db = MockDatabase(operationResults: [
+    let db = ReplayingMockCKDatabase(operationResults: [
       .fetchZoneChanges(
         .init(
           recordWasChangedInZoneResults: [
@@ -302,7 +302,7 @@ final class FetchZoneChangesTests: XCTestCase {
     let changedRecord = CKRecord(recordType: "TestRecord", recordID: changedRecordID)
     let zoneID = CKRecordZone.ID(zoneName: "testZone", ownerName: CKCurrentUserDefaultName)
     
-    let db = MockDatabase(operationResults: [
+    let db = ReplayingMockCKDatabase(operationResults: [
       .fetchZoneChanges(
         .init(
           recordWasChangedInZoneResults: [

--- a/Targets/Canopy/Tests/ModifyRecordsFeatureTests.swift
+++ b/Targets/Canopy/Tests/ModifyRecordsFeatureTests.swift
@@ -12,7 +12,7 @@ final class ModifyRecordsFeatureTests: XCTestCase {
     }
   }
   
-  private var modify_zoneBusy_result: MockDatabase.OperationResult {
+  private var modify_zoneBusy_result: ReplayingMockCKDatabase.OperationResult {
     .modify(
       .init(
         savedRecordResults: [],
@@ -30,7 +30,7 @@ final class ModifyRecordsFeatureTests: XCTestCase {
   }
   
   func test_fails_correctly_on_empty_input() async {
-    let db = MockDatabase(operationResults: [])
+    let db = ReplayingMockCKDatabase(operationResults: [])
     do {
       let _ = try await ModifyRecords.with(
         recordsToSave: [],
@@ -46,19 +46,19 @@ final class ModifyRecordsFeatureTests: XCTestCase {
   
   func test_simple_modify() async {
     let recordsToSave = records(startIndex: 1, endIndex: 10)
-    let db = MockDatabase(
+    let db = ReplayingMockCKDatabase(
       operationResults: [
         .modify(
           .init(
             savedRecordResults:
               recordsToSave.map {
-                MockDatabase.SavedRecordResult(
+                ReplayingMockCKDatabase.SavedRecordResult(
                   recordID: $0.recordID,
                   result: .success($0)
                 )
               },
             deletedRecordIDResults: [],
-            modifyResult: MockDatabase.ModifyResult(result: .success(()))
+            modifyResult: ReplayingMockCKDatabase.ModifyResult(result: .success(()))
           )
         )
       ]
@@ -81,13 +81,13 @@ final class ModifyRecordsFeatureTests: XCTestCase {
   
   func test_simple_delete() async {
     let recordIDsToDelete = records(startIndex: 1, endIndex: 10).map { $0.recordID }
-    let db = MockDatabase(
+    let db = ReplayingMockCKDatabase(
       operationResults: [
         .modify(
           .init(
             savedRecordResults: [],
             deletedRecordIDResults: recordIDsToDelete.map {
-              MockDatabase.DeletedRecordIDResult(
+              ReplayingMockCKDatabase.DeletedRecordIDResult(
                 recordID: $0,
                 result: .success(())
               )
@@ -118,13 +118,13 @@ final class ModifyRecordsFeatureTests: XCTestCase {
     let recordsToSave2 = records(startIndex: 4, endIndex: 6)
     let recordsToSave3 = records(startIndex: 7, endIndex: 9)
     let recordsToSave4 = records(startIndex: 10, endIndex: 11)
-    let db = MockDatabase(
+    let db = ReplayingMockCKDatabase(
       operationResults: [
         .modify(
           .init(
             savedRecordResults:
               recordsToSave1.map {
-                MockDatabase.SavedRecordResult(
+                ReplayingMockCKDatabase.SavedRecordResult(
                   recordID: $0.recordID,
                   result: .success($0)
                 )
@@ -137,7 +137,7 @@ final class ModifyRecordsFeatureTests: XCTestCase {
           .init(
             savedRecordResults:
               recordsToSave2.map {
-                MockDatabase.SavedRecordResult(
+                ReplayingMockCKDatabase.SavedRecordResult(
                   recordID: $0.recordID,
                   result: .success($0)
                 )
@@ -150,7 +150,7 @@ final class ModifyRecordsFeatureTests: XCTestCase {
           .init(
             savedRecordResults:
               recordsToSave3.map {
-                MockDatabase.SavedRecordResult(
+                ReplayingMockCKDatabase.SavedRecordResult(
                   recordID: $0.recordID,
                   result: .success($0)
                 )
@@ -163,7 +163,7 @@ final class ModifyRecordsFeatureTests: XCTestCase {
           .init(
             savedRecordResults:
               recordsToSave4.map {
-                MockDatabase.SavedRecordResult(
+                ReplayingMockCKDatabase.SavedRecordResult(
                   recordID: $0.recordID,
                   result: .success($0)
                 )
@@ -195,13 +195,13 @@ final class ModifyRecordsFeatureTests: XCTestCase {
     let recordsToSave2 = records(startIndex: 4, endIndex: 6)
     let recordsToSave3 = records(startIndex: 7, endIndex: 9)
     let recordsToSave4 = records(startIndex: 10, endIndex: 11)
-    let db = MockDatabase(
+    let db = ReplayingMockCKDatabase(
       operationResults: [
         .modify(
           .init(
             savedRecordResults:
               recordsToSave1.map {
-                MockDatabase.SavedRecordResult(
+                ReplayingMockCKDatabase.SavedRecordResult(
                   recordID: $0.recordID,
                   result: .success($0)
                 )
@@ -214,7 +214,7 @@ final class ModifyRecordsFeatureTests: XCTestCase {
           .init(
             savedRecordResults:
               recordsToSave2.map {
-                MockDatabase.SavedRecordResult(
+                ReplayingMockCKDatabase.SavedRecordResult(
                   recordID: $0.recordID,
                   result: .success($0)
                 )
@@ -227,7 +227,7 @@ final class ModifyRecordsFeatureTests: XCTestCase {
           .init(
             savedRecordResults:
               recordsToSave3.map {
-                MockDatabase.SavedRecordResult(
+                ReplayingMockCKDatabase.SavedRecordResult(
                   recordID: $0.recordID,
                   result: .success($0)
                 )
@@ -240,7 +240,7 @@ final class ModifyRecordsFeatureTests: XCTestCase {
           .init(
             savedRecordResults:
               recordsToSave4.map {
-                MockDatabase.SavedRecordResult(
+                ReplayingMockCKDatabase.SavedRecordResult(
                   recordID: $0.recordID,
                   result: .success($0)
                 )
@@ -279,13 +279,13 @@ final class ModifyRecordsFeatureTests: XCTestCase {
   
   func test_modify_recorderror() async {
     let recordsToSave = records(startIndex: 1, endIndex: 10)
-    let db = MockDatabase(
+    let db = ReplayingMockCKDatabase(
       operationResults: [
         .modify(
           .init(
             savedRecordResults:
               recordsToSave.map {
-                MockDatabase.SavedRecordResult(
+                ReplayingMockCKDatabase.SavedRecordResult(
                   recordID: $0.recordID,
                   result: .failure(CKError(CKError.Code.internalError))
                 )
@@ -314,13 +314,13 @@ final class ModifyRecordsFeatureTests: XCTestCase {
   
   func test_delete_recorderror() async {
     let recordIDsToDelete = records(startIndex: 1, endIndex: 10).map { $0.recordID }
-    let db = MockDatabase(
+    let db = ReplayingMockCKDatabase(
       operationResults: [
         .modify(
           .init(
             savedRecordResults: [],
             deletedRecordIDResults: recordIDsToDelete.map {
-              MockDatabase.DeletedRecordIDResult(
+              ReplayingMockCKDatabase.DeletedRecordIDResult(
                 recordID: $0,
                 result: .failure(CKError(CKError.Code.internalError))
               )
@@ -348,13 +348,13 @@ final class ModifyRecordsFeatureTests: XCTestCase {
   
   func test_modify_resulterror() async {
     let recordsToSave = records(startIndex: 1, endIndex: 10)
-    let db = MockDatabase(
+    let db = ReplayingMockCKDatabase(
       operationResults: [
         .modify(
           .init(
             savedRecordResults:
               recordsToSave.map {
-                MockDatabase.SavedRecordResult(
+                ReplayingMockCKDatabase.SavedRecordResult(
                   recordID: $0.recordID,
                   result: .success($0)
                 )
@@ -384,7 +384,7 @@ final class ModifyRecordsFeatureTests: XCTestCase {
   func test_limit_exceeded() async {
     let recordsToSave = records(startIndex: 1, endIndex: 9)
     let recordIDToDelete = CKRecord.ID(recordName: "idToDelete")
-    let db = MockDatabase(
+    let db = ReplayingMockCKDatabase(
       operationResults: [
         .modify(
           .init(
@@ -396,10 +396,10 @@ final class ModifyRecordsFeatureTests: XCTestCase {
         .modify(
           .init(
             savedRecordResults: recordsToSave[0...3].map {
-              MockDatabase.SavedRecordResult(recordID: $0.recordID, result: .success($0))
+              ReplayingMockCKDatabase.SavedRecordResult(recordID: $0.recordID, result: .success($0))
             },
             deletedRecordIDResults: [
-              MockDatabase.DeletedRecordIDResult(
+              ReplayingMockCKDatabase.DeletedRecordIDResult(
                 recordID: recordIDToDelete,
                 result: .success(())
               )
@@ -410,7 +410,7 @@ final class ModifyRecordsFeatureTests: XCTestCase {
         .modify(
           .init(
             savedRecordResults: recordsToSave[4...7].map {
-              MockDatabase.SavedRecordResult(recordID: $0.recordID, result: .success($0))
+              ReplayingMockCKDatabase.SavedRecordResult(recordID: $0.recordID, result: .success($0))
             },
             deletedRecordIDResults: [],
             modifyResult: .init(result: .success(()))
@@ -419,7 +419,7 @@ final class ModifyRecordsFeatureTests: XCTestCase {
         .modify(
           .init(
             savedRecordResults: [recordsToSave[8]].map {
-              MockDatabase.SavedRecordResult(recordID: $0.recordID, result: .success($0))
+              ReplayingMockCKDatabase.SavedRecordResult(recordID: $0.recordID, result: .success($0))
             },
             deletedRecordIDResults: [],
             modifyResult: .init(result: .success(()))
@@ -450,7 +450,7 @@ final class ModifyRecordsFeatureTests: XCTestCase {
   func test_limit_exceeded_without_autobatch() async {
     let recordsToSave = records(startIndex: 1, endIndex: 9)
     let recordIDToDelete = CKRecord.ID(recordName: "idToDelete")
-    let db = MockDatabase(
+    let db = ReplayingMockCKDatabase(
       operationResults: [
         .modify(
           .init(
@@ -481,7 +481,7 @@ final class ModifyRecordsFeatureTests: XCTestCase {
   
   func test_autoretry_one_pass() async {
     let recordsToSave = records(startIndex: 0, endIndex: 0)
-    let db = MockDatabase(
+    let db = ReplayingMockCKDatabase(
       operationResults: [
         .modify(
           .init(
@@ -513,7 +513,7 @@ final class ModifyRecordsFeatureTests: XCTestCase {
   
   func test_autoretry_one_retry() async {
     let recordsToSave = records(startIndex: 0, endIndex: 0)
-    let db = MockDatabase(
+    let db = ReplayingMockCKDatabase(
       operationResults: [
         modify_zoneBusy_result,
         .modify(
@@ -538,7 +538,7 @@ final class ModifyRecordsFeatureTests: XCTestCase {
   
   func test_autoretry_two_retries() async {
     let recordsToSave = records(startIndex: 0, endIndex: 0)
-    let db = MockDatabase(
+    let db = ReplayingMockCKDatabase(
       operationResults: [
         modify_zoneBusy_result,
         modify_zoneBusy_result,
@@ -564,7 +564,7 @@ final class ModifyRecordsFeatureTests: XCTestCase {
   
   func test_autoretry_three_retries_failure() async {
     let recordsToSave = records(startIndex: 0, endIndex: 0)
-    let db = MockDatabase(
+    let db = ReplayingMockCKDatabase(
       operationResults: [
         modify_zoneBusy_result,
         modify_zoneBusy_result,

--- a/Targets/Canopy/Tests/ModifyRecordsTests.swift
+++ b/Targets/Canopy/Tests/ModifyRecordsTests.swift
@@ -14,7 +14,7 @@ final class ModifyRecordsTests: XCTestCase {
     }
   }
   
-  private var modify_zoneBusy_result: MockDatabase.OperationResult {
+  private var modify_zoneBusy_result: ReplayingMockCKDatabase.OperationResult {
     .modify(
       .init(
         savedRecordResults: [],
@@ -34,7 +34,7 @@ final class ModifyRecordsTests: XCTestCase {
   func test_success() async {
     let recordID = CKRecord.ID(recordName: "TestRecordName")
     let record = CKRecord(recordType: "TestRecord", recordID: recordID)
-    let db = MockDatabase(
+    let db = ReplayingMockCKDatabase(
       operationResults: [
         .modify(
           .init(
@@ -66,7 +66,7 @@ final class ModifyRecordsTests: XCTestCase {
   func test_success_with_delay() async {
     let recordID = CKRecord.ID(recordName: "TestRecordName")
     let record = CKRecord(recordType: "TestRecord", recordID: recordID)
-    let db = MockDatabase(
+    let db = ReplayingMockCKDatabase(
       operationResults: [
         .modify(
           .init(
@@ -98,7 +98,7 @@ final class ModifyRecordsTests: XCTestCase {
   func test_simulated_fail() async {
     let recordID = CKRecord.ID(recordName: "TestRecordName")
     let record = CKRecord(recordType: "TestRecord", recordID: recordID)
-    let db = MockDatabase(
+    let db = ReplayingMockCKDatabase(
       operationResults: [
         .modify(
           .init(
@@ -131,7 +131,7 @@ final class ModifyRecordsTests: XCTestCase {
   func test_simulated_fail_with_delay() async {
     let recordID = CKRecord.ID(recordName: "TestRecordName")
     let record = CKRecord(recordType: "TestRecord", recordID: recordID)
-    let db = MockDatabase(
+    let db = ReplayingMockCKDatabase(
       operationResults: [
         .modify(
           .init(
@@ -165,7 +165,7 @@ final class ModifyRecordsTests: XCTestCase {
     let recordID = CKRecord.ID(recordName: "TestRecordName")
     let recordIDToDelete = CKRecord.ID(recordName: "TestRecordNameToDelete")
     let record = CKRecord(recordType: "TestRecord", recordID: recordID)
-    let db = MockDatabase(
+    let db = ReplayingMockCKDatabase(
       operationResults: [
         .modify(
           .init(
@@ -205,7 +205,7 @@ final class ModifyRecordsTests: XCTestCase {
   func test_explicit_autobatch_true() async {
     let recordsToSave = records(startIndex: 1, endIndex: 10)
     let recordIDToDelete = CKRecord.ID(recordName: "idToDelete")
-    let db = MockDatabase(
+    let db = ReplayingMockCKDatabase(
       operationResults: [
         .modify(
           .init(
@@ -217,10 +217,10 @@ final class ModifyRecordsTests: XCTestCase {
         .modify(
           .init(
             savedRecordResults: recordsToSave[0...9].map {
-              MockDatabase.SavedRecordResult(recordID: $0.recordID, result: .success($0))
+              ReplayingMockCKDatabase.SavedRecordResult(recordID: $0.recordID, result: .success($0))
             },
             deletedRecordIDResults: [
-              MockDatabase.DeletedRecordIDResult(
+              ReplayingMockCKDatabase.DeletedRecordIDResult(
                 recordID: recordIDToDelete,
                 result: .success(())
               )
@@ -257,7 +257,7 @@ final class ModifyRecordsTests: XCTestCase {
   func test_explicit_autobatch_false() async {
     let recordsToSave = records(startIndex: 1, endIndex: 10)
     let recordIDToDelete = CKRecord.ID(recordName: "idToDelete")
-    let db = MockDatabase(
+    let db = ReplayingMockCKDatabase(
       operationResults: [
         .modify(
           .init(
@@ -291,7 +291,7 @@ final class ModifyRecordsTests: XCTestCase {
   
   func test_explicit_autoretry_true() async {
     let recordsToSave = records(startIndex: 0, endIndex: 0)
-    let db = MockDatabase(
+    let db = ReplayingMockCKDatabase(
       operationResults: [
         modify_zoneBusy_result,
         .modify(
@@ -322,7 +322,7 @@ final class ModifyRecordsTests: XCTestCase {
   
   func test_explicit_autoretry_false() async {
     let recordsToSave = records(startIndex: 0, endIndex: 0)
-    let db = MockDatabase(
+    let db = ReplayingMockCKDatabase(
       operationResults: [
         modify_zoneBusy_result,
         .modify(

--- a/Targets/Canopy/Tests/QueryRecordsFeatureTests.swift
+++ b/Targets/Canopy/Tests/QueryRecordsFeatureTests.swift
@@ -14,13 +14,13 @@ final class QueryRecordsFeatureTests: XCTestCase {
   
   func test_simple_query() async {
     let query = CKQuery(recordType: "TestRecord", predicate: NSPredicate(value: true))
-    let db = MockDatabase(
+    let db = ReplayingMockCKDatabase(
       operationResults: [
         .query(
           .init(
             queryRecordResults:
               records(startIndex: 1, endIndex: 10).map {
-                MockDatabase.QueryRecordResult(recordID: $0.recordID, result: .success($0))
+                ReplayingMockCKDatabase.QueryRecordResult(recordID: $0.recordID, result: .success($0))
               },
             queryResult: .init(result: .success(nil))
           )
@@ -42,12 +42,12 @@ final class QueryRecordsFeatureTests: XCTestCase {
   func test_simple_nested_query() async {
     
     let query = CKQuery(recordType: "TestRecord", predicate: NSPredicate(value: true))
-    let db = MockDatabase(
+    let db = ReplayingMockCKDatabase(
       operationResults: [
         .query(
           .init(
             queryRecordResults: records(startIndex: 1, endIndex: 10).map {
-              MockDatabase.QueryRecordResult(recordID: $0.recordID, result: .success($0))
+              ReplayingMockCKDatabase.QueryRecordResult(recordID: $0.recordID, result: .success($0))
             },
             queryResult: .init(result: .success(CKQueryOperation.Cursor.mock))
           )
@@ -55,7 +55,7 @@ final class QueryRecordsFeatureTests: XCTestCase {
         .query(
           .init(
             queryRecordResults: records(startIndex: 11, endIndex: 20).map {
-              MockDatabase.QueryRecordResult(recordID: $0.recordID, result: .success($0))
+              ReplayingMockCKDatabase.QueryRecordResult(recordID: $0.recordID, result: .success($0))
             }, queryResult: .init(result: .success(nil))
           )
         )
@@ -78,12 +78,12 @@ final class QueryRecordsFeatureTests: XCTestCase {
   func test_depth3_query() async {
     
     let query = CKQuery(recordType: "TestRecord", predicate: NSPredicate(value: true))
-    let db = MockDatabase(
+    let db = ReplayingMockCKDatabase(
       operationResults: [
         .query(
           .init(
             queryRecordResults: records(startIndex: 1, endIndex: 3).map {
-              MockDatabase.QueryRecordResult(recordID: $0.recordID, result: .success($0))
+              ReplayingMockCKDatabase.QueryRecordResult(recordID: $0.recordID, result: .success($0))
             },
             queryResult: .init(result: .success(CKQueryOperation.Cursor.mock))
           )
@@ -91,7 +91,7 @@ final class QueryRecordsFeatureTests: XCTestCase {
         .query(
           .init(
             queryRecordResults: records(startIndex: 4, endIndex: 6).map {
-              MockDatabase.QueryRecordResult(recordID: $0.recordID, result: .success($0))
+              ReplayingMockCKDatabase.QueryRecordResult(recordID: $0.recordID, result: .success($0))
             },
             queryResult: .init(result: .success(CKQueryOperation.Cursor.mock))
           )
@@ -99,7 +99,7 @@ final class QueryRecordsFeatureTests: XCTestCase {
         .query(
           .init(
             queryRecordResults: records(startIndex: 7, endIndex: 9).map {
-              MockDatabase.QueryRecordResult(recordID: $0.recordID, result: .success($0))
+              ReplayingMockCKDatabase.QueryRecordResult(recordID: $0.recordID, result: .success($0))
             },
             queryResult: .init(result: .success(nil))
           )
@@ -123,12 +123,12 @@ final class QueryRecordsFeatureTests: XCTestCase {
   func test_task_cancellation_query() async {
     
     let query = CKQuery(recordType: "TestRecord", predicate: NSPredicate(value: true))
-    let db = MockDatabase(
+    let db = ReplayingMockCKDatabase(
       operationResults: [
         .query(
           .init(
             queryRecordResults: records(startIndex: 1, endIndex: 10).map {
-              MockDatabase.QueryRecordResult(recordID: $0.recordID, result: .success($0))
+              ReplayingMockCKDatabase.QueryRecordResult(recordID: $0.recordID, result: .success($0))
             },
             queryResult: .init(result: .success(CKQueryOperation.Cursor.mock))
           )
@@ -136,7 +136,7 @@ final class QueryRecordsFeatureTests: XCTestCase {
         .query(
           .init(
             queryRecordResults: records(startIndex: 11, endIndex: 20).map {
-              MockDatabase.QueryRecordResult(recordID: $0.recordID, result: .success($0))
+              ReplayingMockCKDatabase.QueryRecordResult(recordID: $0.recordID, result: .success($0))
             },
             queryResult: .init(result: .success(nil))
           )
@@ -166,13 +166,13 @@ final class QueryRecordsFeatureTests: XCTestCase {
   
   func test_record_error() async {
     let query = CKQuery(recordType: "TestRecord", predicate: NSPredicate(value: true))
-    let db = MockDatabase(
+    let db = ReplayingMockCKDatabase(
       operationResults: [
         .query(
           .init(
             queryRecordResults:
               records(startIndex: 1, endIndex: 10).map {
-                MockDatabase.QueryRecordResult(recordID: $0.recordID, result: .failure(CKError(CKError.Code.requestRateLimited)))
+                ReplayingMockCKDatabase.QueryRecordResult(recordID: $0.recordID, result: .failure(CKError(CKError.Code.requestRateLimited)))
               },
             queryResult: .init(result: .success(nil))
           )
@@ -192,12 +192,12 @@ final class QueryRecordsFeatureTests: XCTestCase {
   
   func test_nested_request_error() async {
     let query = CKQuery(recordType: "TestRecord", predicate: NSPredicate(value: true))
-    let db = MockDatabase(
+    let db = ReplayingMockCKDatabase(
       operationResults: [
         .query(
           .init(
             queryRecordResults: records(startIndex: 1, endIndex: 3).map {
-              MockDatabase.QueryRecordResult(recordID: $0.recordID, result: .success($0))
+              ReplayingMockCKDatabase.QueryRecordResult(recordID: $0.recordID, result: .success($0))
             },
             queryResult: .init(result: .success(CKQueryOperation.Cursor.mock))
           )
@@ -205,7 +205,7 @@ final class QueryRecordsFeatureTests: XCTestCase {
         .query(
           .init(
             queryRecordResults: records(startIndex: 4, endIndex: 6).map {
-              MockDatabase.QueryRecordResult(recordID: $0.recordID, result: .success($0))
+              ReplayingMockCKDatabase.QueryRecordResult(recordID: $0.recordID, result: .success($0))
             },
             queryResult: .init(result: .failure(CKError(CKError.Code.networkFailure)))
           )

--- a/Targets/Canopy/Tests/SerialFetchChangesTests.swift
+++ b/Targets/Canopy/Tests/SerialFetchChangesTests.swift
@@ -74,7 +74,7 @@ final class SerialFetchChangesTests: XCTestCase {
 
     let privateZoneID1 = CKRecordZone.ID(zoneName: "SomePrivateZone1", ownerName: CKCurrentUserDefaultName)
 
-    let testDB = MockDatabase(
+    let testDB = ReplayingMockCKDatabase(
       operationResults: [
         .fetchDatabaseChanges(
           .init(
@@ -119,7 +119,7 @@ final class SerialFetchChangesTests: XCTestCase {
     
     let privateZoneID1 = CKRecordZone.ID(zoneName: "SomePrivateZone1", ownerName: CKCurrentUserDefaultName)
     
-    let testDB = MockDatabase(
+    let testDB = ReplayingMockCKDatabase(
       operationResults: [
         .fetchZoneChanges(
           .init(

--- a/Targets/CanopyTestTools/Sources/ReplayingMockCKContainer/ReplayingMockCKContainer+AcceptShares.swift
+++ b/Targets/CanopyTestTools/Sources/ReplayingMockCKContainer/ReplayingMockCKContainer+AcceptShares.swift
@@ -1,7 +1,7 @@
 import CanopyTypes
 import CloudKit
 
-extension MockCKContainer {
+extension ReplayingMockCKContainer {
   
   public struct PerShareResult: Codable {
     let shareMetadataArchive: CloudKitShareMetadataArchive

--- a/Targets/CanopyTestTools/Sources/ReplayingMockCKContainer/ReplayingMockCKContainer+AccountStatus.swift
+++ b/Targets/CanopyTestTools/Sources/ReplayingMockCKContainer/ReplayingMockCKContainer+AccountStatus.swift
@@ -1,7 +1,7 @@
 import CanopyTypes
 import CloudKit
 
-extension MockCKContainer {
+extension ReplayingMockCKContainer {
   public struct AccountStatusResult: Codable {
     let statusValue: Int
     let canopyError: CanopyError?

--- a/Targets/CanopyTestTools/Sources/ReplayingMockCKContainer/ReplayingMockCKContainer+FetchShareParticipants.swift
+++ b/Targets/CanopyTestTools/Sources/ReplayingMockCKContainer/ReplayingMockCKContainer+FetchShareParticipants.swift
@@ -1,7 +1,7 @@
 import CloudKit
 import CanopyTypes
 
-extension MockCKContainer {
+extension ReplayingMockCKContainer {
   public struct PerShareParticipantResult: Codable {
     let lookupInfoArchive: CloudKitLookupInfoArchive
     let codableResult: CodableResult<CloudKitShareParticipantArchive, CKRecordError>

--- a/Targets/CanopyTestTools/Sources/ReplayingMockCKContainer/ReplayingMockCKContainer+FetchUserRecordID.swift
+++ b/Targets/CanopyTestTools/Sources/ReplayingMockCKContainer/ReplayingMockCKContainer+FetchUserRecordID.swift
@@ -1,7 +1,7 @@
 import CanopyTypes
 import CloudKit
 
-extension MockCKContainer {
+extension ReplayingMockCKContainer {
   public struct UserRecordIDResult: Codable {
     let userRecordIDArchive: CloudKitRecordIDArchive?
     let recordError: CKRecordError?

--- a/Targets/CanopyTestTools/Sources/ReplayingMockCKContainer/ReplayingMockCKContainer.swift
+++ b/Targets/CanopyTestTools/Sources/ReplayingMockCKContainer/ReplayingMockCKContainer.swift
@@ -2,7 +2,7 @@ import CanopyTypes
 import CloudKit
 import Foundation
 
-public actor MockCKContainer {
+public actor ReplayingMockCKContainer {
   public enum OperationResult: Codable {
     case userRecordID(UserRecordIDResult)
     case accountStatus(AccountStatusResult)
@@ -91,7 +91,7 @@ public actor MockCKContainer {
   }
 }
 
-extension MockCKContainer: CKContainerType {
+extension ReplayingMockCKContainer: CKContainerType {
   nonisolated public func accountStatus(completionHandler: @escaping (CKAccountStatus, Error?) -> Void) {
     Task {
       await privateAccountStatus(completionHandler: completionHandler)

--- a/Targets/CanopyTestTools/Sources/ReplayingMockCKDatabase/ReplayingMockCKDatabase+Fetch.swift
+++ b/Targets/CanopyTestTools/Sources/ReplayingMockCKDatabase/ReplayingMockCKDatabase+Fetch.swift
@@ -1,7 +1,7 @@
 import CloudKit
 import CanopyTypes
 
-extension MockDatabase {
+extension ReplayingMockCKDatabase {
   
   public struct FetchResult: Codable {
     let codableResult: CodableResult<CodableVoid, CKRecordError>

--- a/Targets/CanopyTestTools/Sources/ReplayingMockCKDatabase/ReplayingMockCKDatabase+FetchDatabaseChanges.swift
+++ b/Targets/CanopyTestTools/Sources/ReplayingMockCKDatabase/ReplayingMockCKDatabase+FetchDatabaseChanges.swift
@@ -1,7 +1,7 @@
 import CloudKit
 import CanopyTypes
 
-extension MockDatabase {
+extension ReplayingMockCKDatabase {
   struct FetchDatabaseChangesSuccess: Codable {
     let serverChangeTokenArchive: CloudKitServerChangeTokenArchive
     let moreComing: Bool

--- a/Targets/CanopyTestTools/Sources/ReplayingMockCKDatabase/ReplayingMockCKDatabase+FetchZoneChanges.swift
+++ b/Targets/CanopyTestTools/Sources/ReplayingMockCKDatabase/ReplayingMockCKDatabase+FetchZoneChanges.swift
@@ -1,8 +1,7 @@
 import CloudKit
 import CanopyTypes
 
-extension MockDatabase {
-  
+extension ReplayingMockCKDatabase {
   public struct RecordWasChangedInZoneResult: Codable {
     let recordIDArchive: CloudKitRecordIDArchive
     let codableResult: CodableResult<CloudKitRecordArchive, CKRequestError>

--- a/Targets/CanopyTestTools/Sources/ReplayingMockCKDatabase/ReplayingMockCKDatabase+FetchZones.swift
+++ b/Targets/CanopyTestTools/Sources/ReplayingMockCKDatabase/ReplayingMockCKDatabase+FetchZones.swift
@@ -1,7 +1,7 @@
 import CloudKit
 import CanopyTypes
 
-extension MockDatabase {
+extension ReplayingMockCKDatabase {
   
   public struct FetchZoneResult: Codable {
     

--- a/Targets/CanopyTestTools/Sources/ReplayingMockCKDatabase/ReplayingMockCKDatabase+Modify.swift
+++ b/Targets/CanopyTestTools/Sources/ReplayingMockCKDatabase/ReplayingMockCKDatabase+Modify.swift
@@ -2,7 +2,7 @@ import CloudKit
 import CanopyTypes
 
 // Types and functionality for CKModifyRecordsOperation results.
-extension MockDatabase {
+extension ReplayingMockCKDatabase {
   /// Result for one saved record. perRecordSaveBlock is called with this.
   public struct SavedRecordResult: Codable {
     

--- a/Targets/CanopyTestTools/Sources/ReplayingMockCKDatabase/ReplayingMockCKDatabase+ModifySubscriptions.swift
+++ b/Targets/CanopyTestTools/Sources/ReplayingMockCKDatabase/ReplayingMockCKDatabase+ModifySubscriptions.swift
@@ -1,7 +1,7 @@
 import CloudKit
 import CanopyTypes
 
-extension MockDatabase {
+extension ReplayingMockCKDatabase {
   
   public struct SavedSubscriptionResult: Codable {
     let subscriptionID: CKSubscription.ID

--- a/Targets/CanopyTestTools/Sources/ReplayingMockCKDatabase/ReplayingMockCKDatabase+ModifyZones.swift
+++ b/Targets/CanopyTestTools/Sources/ReplayingMockCKDatabase/ReplayingMockCKDatabase+ModifyZones.swift
@@ -1,7 +1,7 @@
 import CloudKit
 import CanopyTypes
 
-extension MockDatabase {
+extension ReplayingMockCKDatabase {
   
   public struct SavedZoneResult: Codable {
     let zoneIDArchive: CloudKitRecordZoneIDArchive

--- a/Targets/CanopyTestTools/Sources/ReplayingMockCKDatabase/ReplayingMockCKDatabase+Query.swift
+++ b/Targets/CanopyTestTools/Sources/ReplayingMockCKDatabase/ReplayingMockCKDatabase+Query.swift
@@ -2,8 +2,8 @@ import CloudKit
 import CanopyTypes
 
 // Types and functionality for CKQueryOperation results.
-extension MockDatabase {
-  /// Result for one record. recordMatchedBlock is called with this. Also used by MockDatabase+Fetch.
+extension ReplayingMockCKDatabase {
+  /// Result for one record. recordMatchedBlock is called with this. Also used by ReplayingMockCKDatabase+Fetch.
   public struct QueryRecordResult: Codable {
     
     let recordIDArchive: CloudKitRecordIDArchive

--- a/Targets/CanopyTestTools/Sources/ReplayingMockCKDatabase/ReplayingMockCKDatabase.swift
+++ b/Targets/CanopyTestTools/Sources/ReplayingMockCKDatabase/ReplayingMockCKDatabase.swift
@@ -3,7 +3,7 @@ import CloudKit
 import Foundation
 
 /// Mock of CKDatabase, suitable for running CKModifyOperation tests.
-public actor MockDatabase {
+public actor ReplayingMockCKDatabase {
    
   /// How many `add` calls were made to this database.
   public private(set) var operationsRun = 0
@@ -73,8 +73,8 @@ public actor MockDatabase {
   }
 }
 
-extension MockDatabase: CKDatabaseType {
-  nonisolated public var debugDescription: String { "MockDatabase" }
+extension ReplayingMockCKDatabase: CKDatabaseType {
+  nonisolated public var debugDescription: String { "ReplayingMockCKDatabase" }
   
   nonisolated public var databaseScope: CKDatabase.Scope { scope }
   


### PR DESCRIPTION
Renames the CKDatabase and CKContainer mocks to ReplayingMockCKDatabase and ReplayingMockCKContainer, indicating their nature in the name.