### PR TITLE
Fixed NSKeyedUnarchiver API warnings

### DIFF
--- a/Targets/CanopyTypes/Sources/Archiving/CloudKitRecordArchive.swift
+++ b/Targets/CanopyTypes/Sources/Archiving/CloudKitRecordArchive.swift
@@ -11,10 +11,10 @@ import Foundation
 
 public struct CloudKitRecordArchive: Codable {
   private let data: Data
-
+  
   public var records: [CKRecord] {
     do {
-      let decodedRecords = try NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(data)
+      let decodedRecords = try NSKeyedUnarchiver.unarchivedObject(ofClasses: [NSArray.self, CKRecord.self], from: data)
       return decodedRecords as? [CKRecord] ?? []
     } catch {
       return []

--- a/Targets/CanopyTypes/Sources/Archiving/CloudKitRecordArchive.swift
+++ b/Targets/CanopyTypes/Sources/Archiving/CloudKitRecordArchive.swift
@@ -11,7 +11,7 @@ import Foundation
 
 public struct CloudKitRecordArchive: Codable {
   private let data: Data
-  
+
   public var records: [CKRecord] {
     do {
       let decodedRecords = try NSKeyedUnarchiver.unarchivedObject(ofClasses: [NSArray.self, CKRecord.self], from: data)

--- a/Targets/CanopyTypes/Sources/Archiving/CloudKitRecordIDArchive.swift
+++ b/Targets/CanopyTypes/Sources/Archiving/CloudKitRecordIDArchive.swift
@@ -11,7 +11,7 @@ import Foundation
 
 public struct CloudKitRecordIDArchive: Codable {
   private let data: Data
-
+  
   public var recordIDs: [CKRecord.ID] {
     do {
       let decodedRecords = try NSKeyedUnarchiver.unarchivedArrayOfObjects(ofClass: CKRecord.ID.self, from: data)

--- a/Targets/CanopyTypes/Sources/Archiving/CloudKitRecordIDArchive.swift
+++ b/Targets/CanopyTypes/Sources/Archiving/CloudKitRecordIDArchive.swift
@@ -11,7 +11,7 @@ import Foundation
 
 public struct CloudKitRecordIDArchive: Codable {
   private let data: Data
-  
+
   public var recordIDs: [CKRecord.ID] {
     do {
       let decodedRecords = try NSKeyedUnarchiver.unarchivedArrayOfObjects(ofClass: CKRecord.ID.self, from: data)

--- a/Targets/CanopyTypes/Sources/Archiving/CloudKitRecordZoneArchive.swift
+++ b/Targets/CanopyTypes/Sources/Archiving/CloudKitRecordZoneArchive.swift
@@ -6,7 +6,7 @@ public struct CloudKitRecordZoneArchive: Codable {
 
   public var zones: [CKRecordZone] {
     do {
-      let decodedRecords = try NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(data)
+      let decodedRecords = try NSKeyedUnarchiver.unarchivedObject(ofClasses: [NSArray.self, CKRecordZone.self], from: data)
       return decodedRecords as? [CKRecordZone] ?? []
     } catch {
       return []

--- a/Targets/CanopyTypes/Sources/Archiving/CloudKitShareArchive.swift
+++ b/Targets/CanopyTypes/Sources/Archiving/CloudKitShareArchive.swift
@@ -14,7 +14,7 @@ public struct CloudKitShareArchive: Codable {
 
   public var shares: [CKShare] {
     do {
-      let decodedShares = try NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(data)
+      let decodedShares = try NSKeyedUnarchiver.unarchivedObject(ofClasses: [NSArray.self, CKShare.self], from: data)
       return decodedShares as? [CKShare] ?? []
     } catch {
       return []

--- a/Targets/CanopyTypes/Sources/Archiving/CloudKitShareMetadataArchive.swift
+++ b/Targets/CanopyTypes/Sources/Archiving/CloudKitShareMetadataArchive.swift
@@ -6,7 +6,7 @@ public struct CloudKitShareMetadataArchive: Codable {
 
   public var shareMetadatas: [CKShare.Metadata] {
     do {
-      let decodedShareMetadatas = try NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(data)
+      let decodedShareMetadatas = try NSKeyedUnarchiver.unarchivedObject(ofClasses: [NSArray.self, CKShare.Metadata.self], from: data)
       return decodedShareMetadatas as? [CKShare.Metadata] ?? []
     } catch {
       return []

--- a/Targets/CanopyTypes/Sources/Archiving/CloudKitShareParticipantArchive.swift
+++ b/Targets/CanopyTypes/Sources/Archiving/CloudKitShareParticipantArchive.swift
@@ -14,7 +14,7 @@ public struct CloudKitShareParticipantArchive: Codable {
 
   public var shareParticipants: [CKShare.Participant] {
     do {
-      let decodedShareParticipants = try NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(data)
+      let decodedShareParticipants = try NSKeyedUnarchiver.unarchivedObject(ofClasses: [NSArray.self, CKShare.Participant.self], from: data)
       return decodedShareParticipants as? [CKShare.Participant] ?? []
     } catch {
       return []


### PR DESCRIPTION
Fixed deprecated NSKeyedUnarchiver API warnings

Now using modern API which doesn’t produce the deprecation warning any more and works correctly.

It’s a bit counterintuitive to pass both the NSArray and element type as the required classes, but it does seem to work correctly.