### PR TITLE
Fixed parameter sendability warning

### DIFF
--- a/Targets/CanopyTypes/Sources/CKContainerType.swift
+++ b/Targets/CanopyTypes/Sources/CKContainerType.swift
@@ -1,7 +1,7 @@
 import CloudKit
 
 public protocol CKContainerType {
-  func fetchUserRecordID(completionHandler: @escaping (CKRecord.ID?, Error?) -> Void)
-  func accountStatus(completionHandler: @escaping (CKAccountStatus, Error?) -> Void)
+  func fetchUserRecordID(completionHandler: @escaping @Sendable (CKRecord.ID?, Error?) -> Void)
+  func accountStatus(completionHandler: @escaping @Sendable (CKAccountStatus, Error?) -> Void)
   func add(_ operation: CKOperation)
 }


### PR DESCRIPTION
CKContainer API-s at some point added Sendable annotation to the callback blocks, so adding this also to the matching Canopy protocol. This fixes the warning about the function parameters in the protocol and type not matching.