### PR TITLE
Update swift-dependencies to v1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ var dependencies: [PackageDescription.Package.Dependency] = [
   ),
   .package(
     url: "https://github.com/pointfreeco/swift-dependencies",
-    from: "0.2.0"
+    from: "1.0.0"
   )
 ]
 


### PR DESCRIPTION
swift-dependencies did a stable release. Upgrade the version that Canopy requires to reflect that.