### PR TITLE
Add change tag mocking to CKRecord mock

### DIFF
--- a/Targets/Canopy/Tests/MockObjectTests.swift
+++ b/Targets/Canopy/Tests/MockObjectTests.swift
@@ -16,4 +16,10 @@ final class MockObjectTests: XCTestCase {
     let share = CKShare.mock_owned_by_current_user
     XCTAssertEqual(share.participants.count, 3)
   }
+  
+  func test_mock_record_change_tag() {
+    let mockRecord = MockCKRecord(recordType: "MyType")
+    mockRecord[MockCKRecord.testingRecordChangeTag] = "myTag"
+    XCTAssertEqual(mockRecord.recordChangeTag, "myTag")
+  }
 }

--- a/Targets/CanopyTestTools/Sources/MockCKRecord/MockCKRecord.swift
+++ b/Targets/CanopyTestTools/Sources/MockCKRecord/MockCKRecord.swift
@@ -9,14 +9,15 @@ public protocol CKRecordMocking {
 ///
 /// This behaves similarly to CKRecord, but lets you override some fields
 /// that are set by CloudKit on the server side: most importantly,
-/// creator user record name, creation and modification times. This is useful
-/// for testing where you need to test with the content of these fields
+/// creator user record name, creation and modification times, and change tag.
+/// This is useful for testing where you need to test with the content of these fields
 /// present, but are constructing the records locally as test fixtures
 /// instead of obtaining them from the server.
 public class MockCKRecord: CKRecord, CKRecordMocking {
   public static let testingCreatorUserRecordNameKey = "testingCreatorUserRecordNameKey"
   public static let testingCreatedAtKey = "testingCreatedAtKey"
   public static let testingModifiedAtKey = "testingModifiedAtKey"
+  public static let testingRecordChangeTag = "testingRecordChangeTag"
   
   override public var creatorUserRecordID: CKRecord.ID? {
     guard let testing = self[MockCKRecord.testingCreatorUserRecordNameKey] as? String else {
@@ -39,6 +40,13 @@ public class MockCKRecord: CKRecord, CKRecordMocking {
     }
     return testing
   }
+  
+  override public var recordChangeTag: String? {
+    guard let testing = self[MockCKRecord.testingRecordChangeTag] as? String else {
+      return nil
+    }
+    return testing
+  }
 
   override public class var supportsSecureCoding: Bool {
     true
@@ -49,6 +57,7 @@ public class MockCKRecord: CKRecord, CKRecordMocking {
     recordID: CKRecord.ID,
     parentRecordID: CKRecord.ID? = nil,
     creatorUserRecordName: String = UUID().uuidString,
+    recordChangeTag: String? = nil,
     properties: [String: CKRecordValueProtocol?]
   ) -> MockCKRecord {
     let record = MockCKRecord(recordType: recordType, recordID: recordID)
@@ -58,7 +67,8 @@ public class MockCKRecord: CKRecord, CKRecordMocking {
     }
 
     record[testingCreatorUserRecordNameKey] = creatorUserRecordName
-
+    record[testingRecordChangeTag] = recordChangeTag
+    
     for (key, value) in properties {
       record[key] = value
     }
@@ -74,7 +84,8 @@ public class MockCKRecord: CKRecord, CKRecordMocking {
     }
 
     mock[testingCreatorUserRecordNameKey] = record.creatorUserRecordID?.recordName
-
+    mock[testingRecordChangeTag] = record.recordChangeTag
+    
     for key in mock.allKeys() {
       mock[key] = record[key]
     }


### PR DESCRIPTION
This PR adds support for mocking CKRecord change tag. This can be useful in tests that test code which works with change tags.