### PR TITLE
Query results limit

### DIFF
--- a/Targets/Canopy/Sources/CKDatabaseAPI/CKDatabaseAPI.swift
+++ b/Targets/Canopy/Sources/CKDatabaseAPI/CKDatabaseAPI.swift
@@ -74,12 +74,14 @@ class CKDatabaseAPI: CKDatabaseAPIType {
   func queryRecords(
     with query: CKQuery,
     in zoneID: CKRecordZone.ID?,
+    resultsLimit: Int?,
     qos: QualityOfService
   ) async -> Result<[CKRecord], CKRecordError> {
     await QueryRecords.with(
       query,
       recordZoneID: zoneID,
       database: database,
+      resultsLimit: resultsLimit,
       qualityOfService: qos
     )
   }

--- a/Targets/Canopy/Sources/CKDatabaseAPI/CKDatabaseAPIType+Shorthand.swift
+++ b/Targets/Canopy/Sources/CKDatabaseAPI/CKDatabaseAPIType+Shorthand.swift
@@ -45,6 +45,10 @@ public extension CKDatabaseAPIType {
   ///   - with: The `CKQuery` specifying your query. See [CloudKit documentation for CKQuery](https://developer.apple.com/documentation/cloudkit/ckquery)
   ///   about how to construct your query.
   ///   - in: The record zone ID to query the records from. or `nil` to use the default zone.
+  ///   - resultsLimit: An optional number of results to return. By default (if this is `nil`),
+  ///   this function returns all matching results, which may be retrieved across several queries. Specify a results limit
+  ///   to set a cap. Note that this should be equal or lower to the CloudKit limit of maximum results per query, which
+  ///   is around a few hundred.
   ///   - qualityOfService: The desired quality of service of the request. Defaults to `.default` if not provided.
   ///
   /// - Returns:
@@ -53,11 +57,13 @@ public extension CKDatabaseAPIType {
   func queryRecords(
     with query: CKQuery,
     in zoneID: CKRecordZone.ID?,
+    resultsLimit: Int? = nil,
     qualityOfService: QualityOfService = .default
   ) async -> Result<[CKRecord], CKRecordError> {
     await queryRecords(
       with: query,
       in: zoneID,
+      resultsLimit: resultsLimit,
       qos: qualityOfService
     )
   }

--- a/Targets/Canopy/Sources/CKDatabaseAPI/CKDatabaseAPIType.swift
+++ b/Targets/Canopy/Sources/CKDatabaseAPI/CKDatabaseAPIType.swift
@@ -15,10 +15,11 @@ public protocol CKDatabaseAPIType {
   typealias PerRecordProgressBlock = (CKRecord, Double) -> Void
   typealias PerRecordIDProgressBlock = (CKRecord.ID, Double) -> Void
 
-  /// See ``CKDatabaseAPIType/queryRecords(with:in:qualityOfService:)`` for preferred way of calling this API.
+  /// See ``CKDatabaseAPIType/queryRecords(with:in:resultsLimit:qualityOfService:)`` for preferred way of calling this API.
   func queryRecords(
     with query: CKQuery,
     in zoneID: CKRecordZone.ID?,
+    resultsLimit: Int?,
     qos: QualityOfService
   ) async -> Result<[CKRecord], CKRecordError>
 


### PR DESCRIPTION
A new parameter for record querying API, allowing you to specify the maximum number of results to return.