### PR TITLE
Sendable annotations and API adjustments for better Swift concurrency conformance

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -15,7 +15,8 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+    - uses: swift-actions/setup-swift@v2
     - name: Build
       run: swift build -v
     - name: Run tests

--- a/Package.swift
+++ b/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
         "CanopyTypes",
         .product(name: "Dependencies", package: "swift-dependencies")
       ],
-      path: "Targets/Canopy/Sources",
+      path: "Targets/Canopy/Sources"
       // https://danielsaidi.com/blog/2022/05/18/how-to-suppress-linking-warning
       // Canopy by default gives a warning about unsafe code for application extensions. Not sure why it says that.
       // See the above blog post for more info.
@@ -55,33 +55,21 @@ let package = Package(
       // This could also be obsolete, latest Canopy does not give warnings with extensions any more.
       // Keeping this info here just for a while longer.
       // linkerSettings: [.unsafeFlags(["-Xlinker", "-no_application_extension"])]
-      swiftSettings: [
-        .enableExperimentalFeature("StrictConcurrency")
-      ]
     ),
     .target(
       name: "CanopyTestTools",
       dependencies: ["CanopyTypes"],
-      path: "Targets/CanopyTestTools/Sources",
-      swiftSettings: [
-        .enableExperimentalFeature("StrictConcurrency")
-      ]
+      path: "Targets/CanopyTestTools/Sources"
     ),
     .testTarget(
       name: "CanopyTests",
       dependencies: ["Canopy", "CanopyTestTools"],
-      path: "Targets/Canopy/Tests",
-      swiftSettings: [
-        .enableExperimentalFeature("StrictConcurrency")
-      ]
+      path: "Targets/Canopy/Tests"
     ),
     .target(
       name: "CanopyTypes",
       dependencies: [],
-      path: "Targets/CanopyTypes/Sources",
-      swiftSettings: [
-        .enableExperimentalFeature("StrictConcurrency")
-      ]
+      path: "Targets/CanopyTypes/Sources"
     )
   ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -62,17 +62,26 @@ let package = Package(
     .target(
       name: "CanopyTestTools",
       dependencies: ["CanopyTypes"],
-      path: "Targets/CanopyTestTools/Sources"
+      path: "Targets/CanopyTestTools/Sources",
+      swiftSettings: [
+        .enableExperimentalFeature("StrictConcurrency")
+      ]
     ),
     .testTarget(
       name: "CanopyTests",
       dependencies: ["Canopy", "CanopyTestTools"],
-      path: "Targets/Canopy/Tests"
+      path: "Targets/Canopy/Tests",
+      swiftSettings: [
+        .enableExperimentalFeature("StrictConcurrency")
+      ]
     ),
     .target(
       name: "CanopyTypes",
       dependencies: [],
-      path: "Targets/CanopyTypes/Sources"
+      path: "Targets/CanopyTypes/Sources",
+      swiftSettings: [
+        .enableExperimentalFeature("StrictConcurrency")
+      ]
     )
   ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.10
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import Foundation
@@ -47,7 +47,7 @@ let package = Package(
         "CanopyTypes",
         .product(name: "Dependencies", package: "swift-dependencies")
       ],
-      path: "Targets/Canopy/Sources"
+      path: "Targets/Canopy/Sources",
       // https://danielsaidi.com/blog/2022/05/18/how-to-suppress-linking-warning
       // Canopy by default gives a warning about unsafe code for application extensions. Not sure why it says that.
       // See the above blog post for more info.
@@ -55,6 +55,9 @@ let package = Package(
       // This could also be obsolete, latest Canopy does not give warnings with extensions any more.
       // Keeping this info here just for a while longer.
       // linkerSettings: [.unsafeFlags(["-Xlinker", "-no_application_extension"])]
+      swiftSettings: [
+        .enableExperimentalFeature("StrictConcurrency")
+      ]
     ),
     .target(
       name: "CanopyTestTools",

--- a/Targets/Canopy/Sources/CKContainerAPI/CKContainerAPI.swift
+++ b/Targets/Canopy/Sources/CKContainerAPI/CKContainerAPI.swift
@@ -65,7 +65,7 @@ actor CKContainerAPI: CKContainerAPIType {
     statusContinuation?.yield(status)
   }
   
-  nonisolated func fetchShareParticipants(
+  func fetchShareParticipants(
     with lookupInfos: [CKUserIdentity.LookupInfo],
     qos: QualityOfService
   ) async -> Result<[CKShare.Participant], CKRecordError> {

--- a/Targets/Canopy/Sources/CKContainerAPI/CKContainerAPIType.swift
+++ b/Targets/Canopy/Sources/CKContainerAPI/CKContainerAPIType.swift
@@ -16,7 +16,7 @@ public enum CKContainerAPIError: Error {
 /// which lets you skip specifying some parameters and provides reasonable default values for them.
 ///
 /// To access your app’s actual data in CloudKit, see ``CKDatabaseAPIType``.
-public protocol CKContainerAPIType {
+public protocol CKContainerAPIType: Sendable {
   /// Obtain the user record ID for the current CloudKit user.
   ///
   /// You don’t need to do this for regular CloudKit use. Your app doesn’t need to know anything about the current user,

--- a/Targets/Canopy/Sources/CKDatabaseAPI/CKDatabaseAPI+SimulatedFail.swift
+++ b/Targets/Canopy/Sources/CKDatabaseAPI/CKDatabaseAPI+SimulatedFail.swift
@@ -1,5 +1,6 @@
 import CloudKit
 
+@available(iOS 16.4, macOS 13.3, *)
 extension CKDatabaseAPI {
   func randomCKRecordError(
     codes: Set<CKError.Code>,

--- a/Targets/Canopy/Sources/CKDatabaseAPI/CKDatabaseAPI.swift
+++ b/Targets/Canopy/Sources/CKDatabaseAPI/CKDatabaseAPI.swift
@@ -4,6 +4,7 @@ import Foundation
 import os.log
 import Semaphore
 
+@available(iOS 16.4, macOS 13.3, *)
 actor CKDatabaseAPI: CKDatabaseAPIType {
   private let database: CKDatabaseType
   private let databaseScope: CKDatabase.Scope

--- a/Targets/Canopy/Sources/CKDatabaseAPI/CKDatabaseAPI.swift
+++ b/Targets/Canopy/Sources/CKDatabaseAPI/CKDatabaseAPI.swift
@@ -4,7 +4,7 @@ import Foundation
 import os.log
 import Semaphore
 
-class CKDatabaseAPI: CKDatabaseAPIType {
+actor CKDatabaseAPI: CKDatabaseAPIType {
   private let database: CKDatabaseType
   private let databaseScope: CKDatabase.Scope
   internal let settingsProvider: () async -> CanopySettingsType
@@ -16,7 +16,7 @@ class CKDatabaseAPI: CKDatabaseAPIType {
   init(
     database: CKDatabaseType,
     databaseScope: CKDatabase.Scope,
-    settingsProvider: @escaping () async -> CanopySettingsType = { CanopySettings() },
+    settingsProvider: @escaping @Sendable () async -> CanopySettingsType = { CanopySettings() },
     tokenStore: TokenStoreType
   ) {
     self.database = database
@@ -32,7 +32,7 @@ class CKDatabaseAPI: CKDatabaseAPIType {
     qos: QualityOfService
   ) async -> Result<ModifyRecordsResult, CKRecordError> {
     let settings = await settingsProvider()
-    let modifyRecordsBehavior = settings.modifyRecordsBehavior
+    let modifyRecordsBehavior = await settings.modifyRecordsBehavior
     switch modifyRecordsBehavior {
     case let .regular(delay):
       if let delay {

--- a/Targets/Canopy/Sources/CKDatabaseAPI/CKDatabaseAPIType.swift
+++ b/Targets/Canopy/Sources/CKDatabaseAPI/CKDatabaseAPIType.swift
@@ -10,10 +10,10 @@ import Foundation
 ///
 /// Methods of this protocol have a preferred shorthand way of calling them via a protocol extension,
 /// which lets you skip specifying some parameters and provides reasonable default values for them.
-public protocol CKDatabaseAPIType {
+public protocol CKDatabaseAPIType: Sendable {
   
-  typealias PerRecordProgressBlock = (CKRecord, Double) -> Void
-  typealias PerRecordIDProgressBlock = (CKRecord.ID, Double) -> Void
+  typealias PerRecordProgressBlock = @Sendable (CKRecord, Double) -> Void
+  typealias PerRecordIDProgressBlock = @Sendable (CKRecord.ID, Double) -> Void
 
   /// See ``CKDatabaseAPIType/queryRecords(with:in:resultsLimit:qualityOfService:)`` for preferred way of calling this API.
   func queryRecords(

--- a/Targets/Canopy/Sources/Canopy/Canopy.swift
+++ b/Targets/Canopy/Sources/Canopy/Canopy.swift
@@ -7,6 +7,7 @@ import Foundation
 /// You construct Canopy with injected CloudKit container and databases, token store, and settings provider.
 /// Canopy has reasonable defaults for all of these, and you need to only override the ones that need to use
 /// a different value from the default.
+@available(iOS 16.4, macOS 13.3, *)
 public actor Canopy: CanopyType {
   private let containerProvider: @Sendable () -> CKContainerType
   private let publicCloudDatabaseProvider: @Sendable () -> CKDatabaseType

--- a/Targets/Canopy/Sources/Canopy/Canopy.swift
+++ b/Targets/Canopy/Sources/Canopy/Canopy.swift
@@ -8,12 +8,12 @@ import Foundation
 /// Canopy has reasonable defaults for all of these, and you need to only override the ones that need to use
 /// a different value from the default.
 public actor Canopy: CanopyType {
-  private let containerProvider: () -> CKContainerType
-  private let publicCloudDatabaseProvider: () -> CKDatabaseType
-  private let privateCloudDatabaseProvider: () -> CKDatabaseType
-  private let sharedCloudDatabaseProvider: () -> CKDatabaseType
-  private let settingsProvider: () -> CanopySettingsType
-  private let tokenStoreProvider: () -> TokenStoreType
+  private let containerProvider: @Sendable () -> CKContainerType
+  private let publicCloudDatabaseProvider: @Sendable () -> CKDatabaseType
+  private let privateCloudDatabaseProvider: @Sendable () -> CKDatabaseType
+  private let sharedCloudDatabaseProvider: @Sendable () -> CKDatabaseType
+  private let settingsProvider: @Sendable () -> CanopySettingsType
+  private let tokenStoreProvider: @Sendable () -> TokenStoreType
   
   private var containerAPI: CKContainerAPI?
   private var databaseAPIs: [CKDatabase.Scope: CKDatabaseAPI] = [:]
@@ -31,12 +31,12 @@ public actor Canopy: CanopyType {
   ///   - tokenStore: an object that stores and returns zone and database tokens for the requests that work with the tokens.
   ///   Canopy only interacts with the token store when using the ``CKDatabaseAPIType/fetchDatabaseChanges(qualityOfService:)`` and ``CKDatabaseAPIType/fetchZoneChanges(recordZoneIDs:fetchMethod:qualityOfService:)`` APIs. If you don’t use these APIs, you can ignore this parameter.
   public init(
-    container: @escaping @autoclosure () -> CKContainerType = CKContainer.default(),
-    publicCloudDatabase: @escaping @autoclosure () -> CKDatabaseType = CKContainer.default().publicCloudDatabase,
-    privateCloudDatabase: @escaping @autoclosure () -> CKDatabaseType = CKContainer.default().privateCloudDatabase,
-    sharedCloudDatabase: @escaping @autoclosure () -> CKDatabaseType = CKContainer.default().sharedCloudDatabase,
-    settings: @escaping () -> CanopySettingsType = { CanopySettings() },
-    tokenStore: @escaping @autoclosure () -> TokenStoreType = UserDefaultsTokenStore()
+    container: @escaping @autoclosure @Sendable () -> CKContainerType = CKContainer.default(),
+    publicCloudDatabase: @escaping @autoclosure @Sendable () -> CKDatabaseType = CKContainer.default().publicCloudDatabase,
+    privateCloudDatabase: @escaping @autoclosure @Sendable () -> CKDatabaseType = CKContainer.default().privateCloudDatabase,
+    sharedCloudDatabase: @escaping @autoclosure @Sendable () -> CKDatabaseType = CKContainer.default().sharedCloudDatabase,
+    settings: @escaping @Sendable () -> CanopySettingsType = { CanopySettings() },
+    tokenStore: @escaping @autoclosure @Sendable () -> TokenStoreType = UserDefaultsTokenStore()
   ) {
     self.containerProvider = container
     self.publicCloudDatabaseProvider = publicCloudDatabase

--- a/Targets/Canopy/Sources/Canopy/CanopyType.swift
+++ b/Targets/Canopy/Sources/Canopy/CanopyType.swift
@@ -17,7 +17,7 @@ import Foundation
 ///
 /// For testability, you should build your features in a way where they interact with Canopy CloudKit APIs, without needing
 /// to know whether they are talking to a real or mock backend.
-public protocol CanopyType {
+public protocol CanopyType: Sendable {
   
   /// Get the API provider to run requests against a CloudKit container.
   func containerAPI() async -> CKContainerAPIType

--- a/Targets/Canopy/Sources/Canopy/MockCanopy.swift
+++ b/Targets/Canopy/Sources/Canopy/MockCanopy.swift
@@ -12,6 +12,7 @@ import CloudKit
 /// You only need to inject the containers and databases that your tests actually use.
 /// If you try to use a dependency that’s not been injected correctly, MockCanopy crashes
 /// with an error message indicating that.
+@available(iOS 16.4, macOS 13.3, *)
 public struct MockCanopy: CanopyType {
   private let mockPrivateDatabase: CKDatabaseType?
   private let mockSharedDatabase: CKDatabaseType?

--- a/Targets/Canopy/Sources/Canopy/MockCanopy.swift
+++ b/Targets/Canopy/Sources/Canopy/MockCanopy.swift
@@ -17,14 +17,14 @@ public struct MockCanopy: CanopyType {
   private let mockSharedDatabase: CKDatabaseType?
   private let mockPublicDatabase: CKDatabaseType?
   private let mockContainer: CKContainerType?
-  private let settingsProvider: () async -> CanopySettingsType
+  private let settingsProvider: @Sendable () async -> CanopySettingsType
   
   public init(
     mockPrivateDatabase: CKDatabaseType? = nil,
     mockSharedDatabase: CKDatabaseType? = nil,
     mockPublicDatabase: CKDatabaseType? = nil,
     mockContainer: CKContainerType? = nil,
-    settingsProvider: @escaping () async -> CanopySettingsType = { CanopySettings() }
+    settingsProvider: @escaping @Sendable () async -> CanopySettingsType = { CanopySettings() }
   ) {
     self.mockPublicDatabase = mockPublicDatabase
     self.mockSharedDatabase = mockSharedDatabase

--- a/Targets/Canopy/Sources/Dependency/Canopy+Dependency.swift
+++ b/Targets/Canopy/Sources/Dependency/Canopy+Dependency.swift
@@ -1,11 +1,13 @@
 import Dependencies
 
+@available(iOS 16.4, macOS 13.3, *)
 private enum CanopyKey: DependencyKey, Sendable {
   static let liveValue: CanopyType = Canopy()
   static let testValue: CanopyType = MockCanopy()
   static let previewValue: CanopyType = MockCanopy()
 }
 
+@available(iOS 16.4, macOS 13.3, *)
 public extension DependencyValues {
   /// Canopy packaged as CloudKit dependency via swift-dependencies.
   var cloudKit: CanopyType {

--- a/Targets/Canopy/Sources/Dependency/Canopy+Dependency.swift
+++ b/Targets/Canopy/Sources/Dependency/Canopy+Dependency.swift
@@ -1,6 +1,6 @@
 import Dependencies
 
-private enum CanopyKey: DependencyKey {
+private enum CanopyKey: DependencyKey, Sendable {
   static let liveValue: CanopyType = Canopy()
   static let testValue: CanopyType = MockCanopy()
   static let previewValue: CanopyType = MockCanopy()

--- a/Targets/Canopy/Sources/Results/DeletedCKRecord.swift
+++ b/Targets/Canopy/Sources/Results/DeletedCKRecord.swift
@@ -1,6 +1,6 @@
 import CloudKit
 
-public struct DeletedCKRecord: Codable, Equatable {
+public struct DeletedCKRecord: Codable, Equatable, Sendable {
   private let typeString: String
   private let recordName: String
   private let zoneName: String

--- a/Targets/Canopy/Sources/Results/FetchDatabaseChangesResult.swift
+++ b/Targets/Canopy/Sources/Results/FetchDatabaseChangesResult.swift
@@ -1,7 +1,7 @@
 import CloudKit
 import Foundation
 
-public struct FetchDatabaseChangesResult: Equatable {
+public struct FetchDatabaseChangesResult: Equatable, Sendable {
   public let changedRecordZoneIDs: [CKRecordZone.ID]
   public let deletedRecordZoneIDs: [CKRecordZone.ID]
   public let purgedRecordZoneIDs: [CKRecordZone.ID]

--- a/Targets/Canopy/Sources/Results/FetchRecordsResult.swift
+++ b/Targets/Canopy/Sources/Results/FetchRecordsResult.swift
@@ -1,7 +1,7 @@
 import CloudKit
 
 /// Successful result for a function call to fetch records.
-public struct FetchRecordsResult {
+public struct FetchRecordsResult: Sendable {
   /// Records that were found.
   public let foundRecords: [CKRecord]
   

--- a/Targets/Canopy/Sources/Results/FetchZoneChangesMethod.swift
+++ b/Targets/Canopy/Sources/Results/FetchZoneChangesMethod.swift
@@ -8,7 +8,7 @@ import Foundation
 /// Limiting record key fields may reduce the download size if you are
 /// interested only in the tokens, or only some specific fields (but e.g
 /// not asset fields that may contain large files).
-public enum FetchZoneChangesMethod {
+public enum FetchZoneChangesMethod: Sendable {
   /// Fetch tokens and all available data.
   case changeTokenAndAllData
   

--- a/Targets/Canopy/Sources/Results/FetchZoneChangesResult.swift
+++ b/Targets/Canopy/Sources/Results/FetchZoneChangesResult.swift
@@ -1,7 +1,7 @@
 import CloudKit
 import Foundation
 
-public struct FetchZoneChangesResult {
+public struct FetchZoneChangesResult: Sendable {
   public let changedRecords: [CKRecord]
   public let deletedRecords: [DeletedCKRecord]
   

--- a/Targets/Canopy/Sources/Results/ModifyRecordsResult.swift
+++ b/Targets/Canopy/Sources/Results/ModifyRecordsResult.swift
@@ -1,7 +1,7 @@
 import CloudKit
 
 /// Successful result of record modification and deletion functions, containing details about saved and deleted records.
-public struct ModifyRecordsResult: Equatable {
+public struct ModifyRecordsResult: Equatable, Sendable {
   /// An array of saved records. The records likely have different metadata from the records that you gave to the modification function
   /// as input, because CloudKit updates the record modification timestamp and change tag on the server side when saving records.
   public let savedRecords: [CKRecord]

--- a/Targets/Canopy/Sources/Results/ModifySubscriptionsResult.swift
+++ b/Targets/Canopy/Sources/Results/ModifySubscriptionsResult.swift
@@ -1,6 +1,6 @@
 import CloudKit
 
-public struct ModifySubscriptionsResult: Equatable {
+public struct ModifySubscriptionsResult: Equatable, Sendable {
   public let savedSubscriptions: [CKSubscription]
   public let deletedSubscriptionIDs: [CKSubscription.ID]
   

--- a/Targets/Canopy/Sources/Results/ModifyZonesResult.swift
+++ b/Targets/Canopy/Sources/Results/ModifyZonesResult.swift
@@ -1,7 +1,7 @@
 import CloudKit
 import Foundation
 
-public struct ModifyZonesResult: Equatable {
+public struct ModifyZonesResult: Equatable, Sendable {
   public let savedZones: [CKRecordZone]
   public let deletedZoneIDs: [CKRecordZone.ID]
   

--- a/Targets/Canopy/Sources/Settings/CanopySettingsType.swift
+++ b/Targets/Canopy/Sources/Settings/CanopySettingsType.swift
@@ -9,7 +9,7 @@
 /// is to let you test failed requests in a real client environment. You could have a
 /// “developer switch” somewhere in your app to simulate errors, to see how your app
 /// responds to errors in a real build.
-public enum RequestBehavior: Equatable {
+public enum RequestBehavior: Equatable, Sendable {
   /// Regular behavior. Attempt to run the request against the backend. If the optional
   /// associated value is present, the request is delayed for the given number of seconds,
   /// somewhat simulating slow network conditions and letting you see how your UI
@@ -30,17 +30,17 @@ public enum RequestBehavior: Equatable {
 /// By default, Canopy uses reasonable defaults for all these settings. If you would like
 /// to modify Canopy behavior, you can construct Canopy with a `CanopySettings` struct
 /// which has some of the values modified, or pass any custom value that implements this protocol.
-public protocol CanopySettingsType {
+public protocol CanopySettingsType: Sendable {
   /// Behavior for “modify records” request.
   ///
   /// Applies to both saving and deleting records.
-  var modifyRecordsBehavior: RequestBehavior { get }
+  var modifyRecordsBehavior: RequestBehavior { get async }
   
   /// Behavior for “fetch database changes” request.
-  var fetchDatabaseChangesBehavior: RequestBehavior { get }
+  var fetchDatabaseChangesBehavior: RequestBehavior { get async }
   
   /// Behavior for “fetch zone changes” request.
-  var fetchZoneChangesBehavior: RequestBehavior { get }
+  var fetchZoneChangesBehavior: RequestBehavior { get async }
   
   /// Resend a modification request if the initial batch is too large.
   ///
@@ -50,7 +50,7 @@ public protocol CanopySettingsType {
   ///
   /// Canopy does this by default. If you wish, you can turn this off.
   /// You will then get `limitExceeded` error returned.
-  var autoBatchTooLargeModifyOperations: Bool { get }
+  var autoBatchTooLargeModifyOperations: Bool { get async }
   
   /// Retry failed operations that are retriable.
   ///
@@ -66,5 +66,5 @@ public protocol CanopySettingsType {
   ///
   /// Currently this is implemented in Canopy only for modifying records.
   /// All other requests fail immediately without retrying if there is an error.
-  var autoRetryForRetriableErrors: Bool { get }
+  var autoRetryForRetriableErrors: Bool { get async }
 }

--- a/Targets/Canopy/Sources/TokenStore/TestTokenStore.swift
+++ b/Targets/Canopy/Sources/TokenStore/TestTokenStore.swift
@@ -6,7 +6,7 @@ import CloudKit
 ///
 /// The function call counts are used by Canopy test suite. You can also use them in your own tests, to make sure
 /// that the tokens are actually stored and requested as you expect.
-public class TestTokenStore: TokenStoreType {
+public actor TestTokenStore: TokenStoreType {
   public init() {}
   
   /// How many times "storeToken:forDatabaseScope:" has been called.

--- a/Targets/Canopy/Sources/TokenStore/TokenStoreType.swift
+++ b/Targets/Canopy/Sources/TokenStore/TokenStoreType.swift
@@ -17,7 +17,7 @@ import CloudKit
 /// TokenStore and Canopy currently assume that the application works with only one CKContainer.
 /// There is currently no facility to distinguish between multiple CKContainers. This is a good enough assumption
 /// for most CloudKit applications.
-public protocol TokenStoreType {
+public protocol TokenStoreType: Sendable {
   /// Store a token for the given database scope.
   ///
   /// - Parameter token: token to be stored. May be nil if it needs to be removed from storage for whatever reason.

--- a/Targets/Canopy/Sources/TokenStore/UserDefaultsTokenStore.swift
+++ b/Targets/Canopy/Sources/TokenStore/UserDefaultsTokenStore.swift
@@ -7,7 +7,7 @@ import os.log
 /// on macOS during development, because the `defaults` command-line utility and many other tools
 /// provide you easy access to the stored tokens in your system. You can verify that the tokens do get stored,
 /// and clear them manually if needed.
-public struct UserDefaultsTokenStore: TokenStoreType {
+public actor UserDefaultsTokenStore: TokenStoreType {
   private let logger = Logger(subsystem: "Canopy", category: "UserDefaultsTokenStore")
   
   public init() {}

--- a/Targets/Canopy/Tests/CanopyTests.swift
+++ b/Targets/Canopy/Tests/CanopyTests.swift
@@ -18,15 +18,19 @@ final class CanopyTests: XCTestCase {
     let changedRecordID = CKRecord.ID(recordName: "SomeRecordName")
     let changedRecord = CKRecord(recordType: "TestRecord", recordID: changedRecordID)
     
-    struct ModifiableSettings: CanopySettingsType {
+    actor ModifiableSettings: CanopySettingsType {
       var modifyRecordsBehavior: RequestBehavior = .regular(nil)
-      var fetchZoneChangesBehavior: RequestBehavior = .regular(nil)
-      var fetchDatabaseChangesBehavior: RequestBehavior = .regular(nil)
-      var autoBatchTooLargeModifyOperations: Bool = true
-      var autoRetryForRetriableErrors: Bool = true
+      let fetchZoneChangesBehavior: RequestBehavior = .regular(nil)
+      let fetchDatabaseChangesBehavior: RequestBehavior = .regular(nil)
+      let autoBatchTooLargeModifyOperations: Bool = true
+      let autoRetryForRetriableErrors: Bool = true
+      
+      func setModifyRecordsBehavior(behavior: RequestBehavior) {
+        modifyRecordsBehavior = behavior
+      }
     }
     
-    var modifiableSettings = ModifiableSettings()
+    let modifiableSettings = ModifiableSettings()
     
     let canopy = Canopy(
       container: ReplayingMockCKContainer(),
@@ -64,7 +68,7 @@ final class CanopyTests: XCTestCase {
     XCTAssertTrue(result1.savedRecords[0].isEqualToRecord(changedRecord))
     
     // Second request will fail after modifying the settings.
-    modifiableSettings.modifyRecordsBehavior = .simulatedFail(nil)
+    await modifiableSettings.setModifyRecordsBehavior(behavior: .simulatedFail(nil))
     
     do {
       let _ = try await api.modifyRecords(saving: [changedRecord]).get()

--- a/Targets/Canopy/Tests/CanopyTests.swift
+++ b/Targets/Canopy/Tests/CanopyTests.swift
@@ -3,6 +3,7 @@ import CanopyTestTools
 import CloudKit
 import XCTest
 
+@available(iOS 16.4, macOS 13.3, *)
 final class CanopyTests: XCTestCase {
   func test_init_with_default_settings() async {
     let _ = Canopy(

--- a/Targets/Canopy/Tests/DatabaseAPITests.swift
+++ b/Targets/Canopy/Tests/DatabaseAPITests.swift
@@ -8,6 +8,7 @@ import XCTest
 /// Contains most Canopy database API tests.
 ///
 /// Some tests are in individual test classes (fetch changes).
+@available(iOS 16.4, macOS 13.3, *)
 final class DatabaseAPITests: XCTestCase {
   private func databaseAPI(_ db: CKDatabaseType, settings: CanopySettingsType = CanopySettings()) -> CKDatabaseAPIType {
     CKDatabaseAPI(database: db, databaseScope: .private, settingsProvider: { settings }, tokenStore: TestTokenStore())

--- a/Targets/Canopy/Tests/DependencyTests.swift
+++ b/Targets/Canopy/Tests/DependencyTests.swift
@@ -4,6 +4,7 @@ import CloudKit
 import Dependencies
 import XCTest
 
+@available(iOS 16.4, macOS 13.3, *)
 final class DependencyTests: XCTestCase {
   struct Fetcher {
     @Dependency(\.cloudKit) private var canopy

--- a/Targets/Canopy/Tests/FetchDatabaseChangesTests.swift
+++ b/Targets/Canopy/Tests/FetchDatabaseChangesTests.swift
@@ -5,6 +5,7 @@ import CloudKit
 import Foundation
 import XCTest
 
+@available(iOS 16.4, macOS 13.3, *)
 final class FetchDatabaseChangesTests: XCTestCase {
   func test_success() async {
     let changedRecordZoneID1 = CKRecordZone.ID(zoneName: "changedZone1", ownerName: CKCurrentUserDefaultName)

--- a/Targets/Canopy/Tests/FetchDatabaseChangesTests.swift
+++ b/Targets/Canopy/Tests/FetchDatabaseChangesTests.swift
@@ -29,8 +29,12 @@ final class FetchDatabaseChangesTests: XCTestCase {
       deletedRecordZoneIDs: [deletedRecordZoneID],
       purgedRecordZoneIDs: [purgedRecordZoneID]
     ))
-    XCTAssertEqual(testTokenStore.getTokenForDatabaseScopeCalls, 1)
-    XCTAssertEqual(testTokenStore.storeTokenForDatabaseScopeCalls, 1)
+    
+    let getTokenForDatabaseScopeCalls = await testTokenStore.getTokenForDatabaseScopeCalls
+    let storeTokenForDatabaseScopeCalls = await testTokenStore.storeTokenForDatabaseScopeCalls
+    
+    XCTAssertEqual(getTokenForDatabaseScopeCalls, 1)
+    XCTAssertEqual(storeTokenForDatabaseScopeCalls, 1)
   }
   
   func test_token_expired_error() async {
@@ -50,7 +54,8 @@ final class FetchDatabaseChangesTests: XCTestCase {
       let _ = try await api.fetchDatabaseChanges().get()
     } catch {
       XCTAssertEqual(error as! CanopyError, CanopyError.ckChangeTokenExpired)
-      XCTAssertEqual(testTokenStore.storeTokenForDatabaseScopeCalls, 1) // nil token was stored
+      let storeTokenForDatabaseScopeCalls = await testTokenStore.storeTokenForDatabaseScopeCalls
+      XCTAssertEqual(storeTokenForDatabaseScopeCalls, 1) // nil token was stored
     }
   }
   
@@ -71,7 +76,8 @@ final class FetchDatabaseChangesTests: XCTestCase {
       let _ = try await api.fetchDatabaseChanges().get()
     } catch {
       XCTAssertEqual(error as! CanopyError, CanopyError.ckRequestError(CKRequestError(from: CKError(CKError.Code.networkFailure))))
-      XCTAssertEqual(testTokenStore.storeTokenForDatabaseScopeCalls, 0) // nothing should have been stored
+      let storeTokenForDatabaseScopeCalls = await testTokenStore.storeTokenForDatabaseScopeCalls
+      XCTAssertEqual(storeTokenForDatabaseScopeCalls, 0) // nothing should have been stored
     }
   }
   
@@ -102,8 +108,10 @@ final class FetchDatabaseChangesTests: XCTestCase {
       deletedRecordZoneIDs: [],
       purgedRecordZoneIDs: []
     ))
-    XCTAssertEqual(testTokenStore.getTokenForDatabaseScopeCalls, 1)
-    XCTAssertEqual(testTokenStore.storeTokenForDatabaseScopeCalls, 1)
+    let getTokenForDatabaseScopeCalls = await testTokenStore.getTokenForDatabaseScopeCalls
+    let storeTokenForDatabaseScopeCalls = await testTokenStore.storeTokenForDatabaseScopeCalls
+    XCTAssertEqual(getTokenForDatabaseScopeCalls, 1)
+    XCTAssertEqual(storeTokenForDatabaseScopeCalls, 1)
   }
   
   func test_simulated_fail() async {
@@ -136,8 +144,11 @@ final class FetchDatabaseChangesTests: XCTestCase {
       default:
         XCTFail("Unexpected error type: \(error)")
       }
-      XCTAssertEqual(testTokenStore.getTokenForDatabaseScopeCalls, 0)
-      XCTAssertEqual(testTokenStore.storeTokenForDatabaseScopeCalls, 0)
+      let getTokenForDatabaseScopeCalls = await testTokenStore.getTokenForDatabaseScopeCalls
+      let storeTokenForDatabaseScopeCalls = await testTokenStore.storeTokenForDatabaseScopeCalls
+
+      XCTAssertEqual(getTokenForDatabaseScopeCalls, 0)
+      XCTAssertEqual(storeTokenForDatabaseScopeCalls, 0)
     }
   }
   
@@ -171,8 +182,12 @@ final class FetchDatabaseChangesTests: XCTestCase {
       default:
         XCTFail("Unexpected error type: \(error)")
       }
-      XCTAssertEqual(testTokenStore.getTokenForDatabaseScopeCalls, 0)
-      XCTAssertEqual(testTokenStore.storeTokenForDatabaseScopeCalls, 0)
+      
+      let getTokenForDatabaseScopeCalls = await testTokenStore.getTokenForDatabaseScopeCalls
+      let storeTokenForDatabaseScopeCalls = await testTokenStore.storeTokenForDatabaseScopeCalls
+
+      XCTAssertEqual(getTokenForDatabaseScopeCalls, 0)
+      XCTAssertEqual(storeTokenForDatabaseScopeCalls, 0)
     }
   }
 }

--- a/Targets/Canopy/Tests/FetchZoneChangesTests.swift
+++ b/Targets/Canopy/Tests/FetchZoneChangesTests.swift
@@ -40,8 +40,10 @@ final class FetchZoneChangesTests: XCTestCase {
     ).get()
     XCTAssertTrue(result.changedRecords.first!.isEqualToRecord(changedRecord))
     XCTAssertEqual(result.deletedRecords, [])
-    XCTAssertEqual(tokenStore.getTokenForRecordZoneCalls, 1)
-    XCTAssertEqual(tokenStore.storeTokenForRecordZoneCalls, 1)
+    let getTokenForRecordZoneCalls = await tokenStore.getTokenForRecordZoneCalls
+    let storeTokenForRecordZoneCalls = await tokenStore.storeTokenForRecordZoneCalls
+    XCTAssertEqual(getTokenForRecordZoneCalls, 1)
+    XCTAssertEqual(storeTokenForRecordZoneCalls, 1)
   }
   
   func test_fetch_tokens_only() async {
@@ -78,8 +80,10 @@ final class FetchZoneChangesTests: XCTestCase {
     ).get()
     XCTAssertEqual(result.changedRecords, [])
     XCTAssertEqual(result.deletedRecords, [])
-    XCTAssertEqual(tokenStore.getTokenForRecordZoneCalls, 1)
-    XCTAssertEqual(tokenStore.storeTokenForRecordZoneCalls, 1)
+    let getTokenForRecordZoneCalls = await tokenStore.getTokenForRecordZoneCalls
+    let storeTokenForRecordZoneCalls = await tokenStore.storeTokenForRecordZoneCalls
+    XCTAssertEqual(getTokenForRecordZoneCalls, 1)
+    XCTAssertEqual(storeTokenForRecordZoneCalls, 1)
   }
   
   func test_record_error() async {
@@ -120,7 +124,8 @@ final class FetchZoneChangesTests: XCTestCase {
       ).get()
     } catch {
       XCTAssertEqual(error as! CanopyError, .ckRecordError(.init(from: CKError(CKError.Code.networkUnavailable))))
-      XCTAssertEqual(tokenStore.storeTokenForRecordZoneCalls, 0)
+      let storeTokenForRecordZoneCalls = await tokenStore.storeTokenForRecordZoneCalls
+      XCTAssertEqual(storeTokenForRecordZoneCalls, 0)
     }
   }
   
@@ -156,9 +161,12 @@ final class FetchZoneChangesTests: XCTestCase {
         fetchMethod: .changeTokenAndAllData
       ).get()
     } catch {
-      XCTAssertEqual(tokenStore.getTokenForRecordZoneCalls, 2)
+      let getTokenForRecordZoneCalls = await tokenStore.getTokenForRecordZoneCalls
+      let storeTokenForRecordZoneCalls = await tokenStore.storeTokenForRecordZoneCalls
+
+      XCTAssertEqual(getTokenForRecordZoneCalls, 2)
       // Stored only one nil token
-      XCTAssertEqual(tokenStore.storeTokenForRecordZoneCalls, 1)
+      XCTAssertEqual(storeTokenForRecordZoneCalls, 1)
       XCTAssertEqual(error as! CanopyError, .ckRecordZoneError(.init(from: CKError(CKError.Code.changeTokenExpired))))
     }
   }
@@ -194,8 +202,11 @@ final class FetchZoneChangesTests: XCTestCase {
         fetchMethod: .changeTokenAndAllData
       ).get()
     } catch {
-      XCTAssertEqual(tokenStore.getTokenForRecordZoneCalls, 1)
-      XCTAssertEqual(tokenStore.storeTokenForRecordZoneCalls, 0)
+      let getTokenForRecordZoneCalls = await tokenStore.getTokenForRecordZoneCalls
+      let storeTokenForRecordZoneCalls = await tokenStore.storeTokenForRecordZoneCalls
+
+      XCTAssertEqual(getTokenForRecordZoneCalls, 1)
+      XCTAssertEqual(storeTokenForRecordZoneCalls, 0)
       
       XCTAssertEqual(error as! CanopyError, .ckRequestError(.init(from: CKError(CKError.Code.accountTemporarilyUnavailable))))
     }
@@ -235,8 +246,11 @@ final class FetchZoneChangesTests: XCTestCase {
     ).get()
     XCTAssertTrue(result.changedRecords.first!.isEqualToRecord(changedRecord))
     XCTAssertEqual(result.deletedRecords, [])
-    XCTAssertEqual(tokenStore.getTokenForRecordZoneCalls, 1)
-    XCTAssertEqual(tokenStore.storeTokenForRecordZoneCalls, 1)
+    let getTokenForRecordZoneCalls = await tokenStore.getTokenForRecordZoneCalls
+    let storeTokenForRecordZoneCalls = await tokenStore.storeTokenForRecordZoneCalls
+
+    XCTAssertEqual(getTokenForRecordZoneCalls, 1)
+    XCTAssertEqual(storeTokenForRecordZoneCalls, 1)
   }
   
   func test_simulated_fail() async {
@@ -279,8 +293,11 @@ final class FetchZoneChangesTests: XCTestCase {
       default:
         XCTFail("Unexpected error type: \(error)")
       }
-      XCTAssertEqual(tokenStore.getTokenForRecordZoneCalls, 0)
-      XCTAssertEqual(tokenStore.storeTokenForRecordZoneCalls, 0)
+      let getTokenForRecordZoneCalls = await tokenStore.getTokenForRecordZoneCalls
+      let storeTokenForRecordZoneCalls = await tokenStore.storeTokenForRecordZoneCalls
+
+      XCTAssertEqual(getTokenForRecordZoneCalls, 0)
+      XCTAssertEqual(storeTokenForRecordZoneCalls, 0)
     }
   }
   
@@ -324,8 +341,11 @@ final class FetchZoneChangesTests: XCTestCase {
       default:
         XCTFail("Unexpected error type: \(error)")
       }
-      XCTAssertEqual(tokenStore.getTokenForRecordZoneCalls, 0)
-      XCTAssertEqual(tokenStore.storeTokenForRecordZoneCalls, 0)
+      let getTokenForRecordZoneCalls = await tokenStore.getTokenForRecordZoneCalls
+      let storeTokenForRecordZoneCalls = await tokenStore.storeTokenForRecordZoneCalls
+
+      XCTAssertEqual(getTokenForRecordZoneCalls, 0)
+      XCTAssertEqual(storeTokenForRecordZoneCalls, 0)
     }
   }
 }

--- a/Targets/Canopy/Tests/FetchZoneChangesTests.swift
+++ b/Targets/Canopy/Tests/FetchZoneChangesTests.swift
@@ -5,6 +5,7 @@ import CloudKit
 import Foundation
 import XCTest
 
+@available(iOS 16.4, macOS 13.3, *)
 final class FetchZoneChangesTests: XCTestCase {
   func test_success() async {
     let changedRecordID = CKRecord.ID(recordName: "SomeRecordName")

--- a/Targets/Canopy/Tests/ModifyRecordsTests.swift
+++ b/Targets/Canopy/Tests/ModifyRecordsTests.swift
@@ -3,6 +3,7 @@ import CanopyTestTools
 import CloudKit
 import XCTest
 
+@available(iOS 16.4, macOS 13.3, *)
 final class ModifyRecordsTests: XCTestCase {
   private func databaseAPI(_ db: CKDatabaseType, settings: CanopySettingsType = CanopySettings()) -> CKDatabaseAPIType {
     CKDatabaseAPI(database: db, databaseScope: .private, settingsProvider: { settings }, tokenStore: TestTokenStore())

--- a/Targets/Canopy/Tests/QueryRecordsFeatureTests.swift
+++ b/Targets/Canopy/Tests/QueryRecordsFeatureTests.swift
@@ -5,6 +5,7 @@ import CloudKit
 import Foundation
 import XCTest
 
+@available(iOS 17, macOS 14, *)
 final class QueryRecordsFeatureTests: XCTestCase {
   func records(startIndex: Int, endIndex: Int) -> [CKRecord] {
     stride(from: startIndex, to: endIndex + 1, by: 1).map { i in

--- a/Targets/Canopy/Tests/SerialFetchChangesTests.swift
+++ b/Targets/Canopy/Tests/SerialFetchChangesTests.swift
@@ -18,6 +18,7 @@ import XCTest
 /// fetches. Next fetches wait for previous ones to finish.
 ///
 /// These tests make sure that this behavior is correct.
+@available(iOS 16.4, macOS 13.3, *)
 final class SerialFetchChangesTests: XCTestCase {
   /// A token store that balances calls to getting and storing tokens.
   ///

--- a/Targets/CanopyTestTools/Sources/CodableResult.swift
+++ b/Targets/CanopyTestTools/Sources/CodableResult.swift
@@ -5,7 +5,7 @@
 ///
 /// This does not include conversion to/from the actual Result because we may want to
 /// massage the types a bit. Conversion should be done at the sites of use.
-enum CodableResult<T, E>: Codable where T: Codable, E: Error, E: Codable {
+enum CodableResult<T, E>: Codable, Sendable where T: Codable, T: Sendable, E: Error, E: Codable, E: Sendable {
   case success(T)
   case failure(E)
 }

--- a/Targets/CanopyTestTools/Sources/ReplayingMockCKContainer/ReplayingMockCKContainer+AcceptShares.swift
+++ b/Targets/CanopyTestTools/Sources/ReplayingMockCKContainer/ReplayingMockCKContainer+AcceptShares.swift
@@ -2,7 +2,7 @@ import CanopyTypes
 import CloudKit
 
 public extension ReplayingMockCKContainer {
-  struct PerShareResult: Codable {
+  struct PerShareResult: Codable, Sendable {
     let shareMetadataArchive: CloudKitShareMetadataArchive
     let codableResult: CodableResult<CloudKitShareArchive, CKRecordError>
     
@@ -22,7 +22,7 @@ public extension ReplayingMockCKContainer {
     }
   }
   
-  struct AcceptSharesResult: Codable {
+  struct AcceptSharesResult: Codable, Sendable {
     let codableResult: CodableResult<CodableVoid, CKRecordError>
     
     public init(result: Result<Void, Error>) {
@@ -40,7 +40,7 @@ public extension ReplayingMockCKContainer {
     }
   }
   
-  struct AcceptSharesOperationResult: Codable {
+  struct AcceptSharesOperationResult: Codable, Sendable {
     let perShareResults: [PerShareResult]
     let acceptSharesResult: AcceptSharesResult
     

--- a/Targets/CanopyTestTools/Sources/ReplayingMockCKContainer/ReplayingMockCKContainer+AccountStatus.swift
+++ b/Targets/CanopyTestTools/Sources/ReplayingMockCKContainer/ReplayingMockCKContainer+AccountStatus.swift
@@ -2,7 +2,7 @@ import CanopyTypes
 import CloudKit
 
 public extension ReplayingMockCKContainer {
-  struct AccountStatusResult: Codable {
+  struct AccountStatusResult: Codable, Sendable {
     let statusValue: Int
     let canopyError: CanopyError?
     

--- a/Targets/CanopyTestTools/Sources/ReplayingMockCKContainer/ReplayingMockCKContainer+FetchShareParticipants.swift
+++ b/Targets/CanopyTestTools/Sources/ReplayingMockCKContainer/ReplayingMockCKContainer+FetchShareParticipants.swift
@@ -2,7 +2,7 @@ import CanopyTypes
 import CloudKit
 
 public extension ReplayingMockCKContainer {
-  struct PerShareParticipantResult: Codable {
+  struct PerShareParticipantResult: Codable, Sendable {
     let lookupInfoArchive: CloudKitLookupInfoArchive
     let codableResult: CodableResult<CloudKitShareParticipantArchive, CKRecordError>
     
@@ -22,7 +22,7 @@ public extension ReplayingMockCKContainer {
     }
   }
   
-  struct FetchShareParticipantsResult: Codable {
+  struct FetchShareParticipantsResult: Codable, Sendable {
     let codableResult: CodableResult<CodableVoid, CKRecordError>
     
     public init(result: Result<Void, Error>) {
@@ -40,7 +40,7 @@ public extension ReplayingMockCKContainer {
     }
   }
   
-  struct FetchShareParticipantsOperationResult: Codable {
+  struct FetchShareParticipantsOperationResult: Codable, Sendable {
     let perShareParticipantResults: [PerShareParticipantResult]
     let fetchShareParticipantsResult: FetchShareParticipantsResult
     

--- a/Targets/CanopyTestTools/Sources/ReplayingMockCKContainer/ReplayingMockCKContainer+FetchUserRecordID.swift
+++ b/Targets/CanopyTestTools/Sources/ReplayingMockCKContainer/ReplayingMockCKContainer+FetchUserRecordID.swift
@@ -2,7 +2,7 @@ import CanopyTypes
 import CloudKit
 
 public extension ReplayingMockCKContainer {
-  struct UserRecordIDResult: Codable {
+  struct UserRecordIDResult: Codable, Sendable {
     let userRecordIDArchive: CloudKitRecordIDArchive?
     let recordError: CKRecordError?
     

--- a/Targets/CanopyTestTools/Sources/ReplayingMockCKContainer/ReplayingMockCKContainer.swift
+++ b/Targets/CanopyTestTools/Sources/ReplayingMockCKContainer/ReplayingMockCKContainer.swift
@@ -3,7 +3,7 @@ import CloudKit
 import Foundation
 
 public actor ReplayingMockCKContainer {
-  public enum OperationResult: Codable {
+  public enum OperationResult: Codable, Sendable {
     case userRecordID(UserRecordIDResult)
     case accountStatus(AccountStatusResult)
     case fetchShareParticipants(FetchShareParticipantsOperationResult)

--- a/Targets/CanopyTestTools/Sources/ReplayingMockCKDatabase/ReplayingMockCKDatabase+Fetch.swift
+++ b/Targets/CanopyTestTools/Sources/ReplayingMockCKDatabase/ReplayingMockCKDatabase+Fetch.swift
@@ -2,7 +2,7 @@ import CanopyTypes
 import CloudKit
 
 public extension ReplayingMockCKDatabase {
-  struct FetchResult: Codable {
+  struct FetchResult: Codable, Sendable {
     let codableResult: CodableResult<CodableVoid, CKRecordError>
     
     public init(result: Result<Void, Error>) {
@@ -20,7 +20,7 @@ public extension ReplayingMockCKDatabase {
     }
   }
 
-  struct FetchOperationResult: Codable {
+  struct FetchOperationResult: Codable, Sendable {
     public let fetchRecordResults: [QueryRecordResult]
     public let fetchResult: FetchResult
     

--- a/Targets/CanopyTestTools/Sources/ReplayingMockCKDatabase/ReplayingMockCKDatabase+FetchDatabaseChanges.swift
+++ b/Targets/CanopyTestTools/Sources/ReplayingMockCKDatabase/ReplayingMockCKDatabase+FetchDatabaseChanges.swift
@@ -7,7 +7,7 @@ extension ReplayingMockCKDatabase {
     let moreComing: Bool
   }
   
-  public struct FetchDatabaseChangesResult: Codable {
+  public struct FetchDatabaseChangesResult: Codable, Sendable {
     let codableResult: CodableResult<FetchDatabaseChangesSuccess, CanopyError>
     
     public static let success = FetchDatabaseChangesResult(result: .success((serverChangeToken: CKServerChangeToken.mock, moreComing: false)))
@@ -29,7 +29,7 @@ extension ReplayingMockCKDatabase {
     }
   }
   
-  public struct FetchDatabaseChangesOperationResult: Codable {
+  public struct FetchDatabaseChangesOperationResult: Codable, Sendable {
     /// A successful result that indicates no changes.
     ///
     /// Useful to use in tests and previews where you don’t need to inject any results, to save some typing.

--- a/Targets/CanopyTestTools/Sources/ReplayingMockCKDatabase/ReplayingMockCKDatabase+FetchZoneChanges.swift
+++ b/Targets/CanopyTestTools/Sources/ReplayingMockCKDatabase/ReplayingMockCKDatabase+FetchZoneChanges.swift
@@ -2,7 +2,7 @@ import CanopyTypes
 import CloudKit
 
 public extension ReplayingMockCKDatabase {
-  struct RecordWasChangedInZoneResult: Codable {
+  struct RecordWasChangedInZoneResult: Codable, Sendable {
     let recordIDArchive: CloudKitRecordIDArchive
     let codableResult: CodableResult<CloudKitRecordArchive, CKRequestError>
     
@@ -22,7 +22,7 @@ public extension ReplayingMockCKDatabase {
     }
   }
   
-  struct RecordWithIDWasDeletedInZoneResult: Codable {
+  struct RecordWithIDWasDeletedInZoneResult: Codable, Sendable {
     let recordIDArchive: CloudKitRecordIDArchive
     let recordType: CKRecord.RecordType
     
@@ -32,13 +32,13 @@ public extension ReplayingMockCKDatabase {
     }
   }
   
-  internal struct OneZoneFetchResultSuccess: Codable {
+  internal struct OneZoneFetchResultSuccess: Codable, Sendable {
     let serverChangeTokenArchive: CloudKitServerChangeTokenArchive
     let clientChangeTokenData: Data?
     let moreComing: Bool
   }
   
-  struct OneZoneFetchResult: Codable {
+  struct OneZoneFetchResult: Codable, Sendable {
     let zoneIDArchive: CloudKitRecordZoneIDArchive
     let codableResult: CodableResult<OneZoneFetchResultSuccess, CKRequestError>
 
@@ -78,7 +78,7 @@ public extension ReplayingMockCKDatabase {
     }
   }
   
-  struct FetchZoneChangesResult: Codable {
+  struct FetchZoneChangesResult: Codable, Sendable {
     let codableResult: CodableResult<CodableVoid, CKRequestError>
         
     public init(result: Result<Void, Error>) {
@@ -96,7 +96,7 @@ public extension ReplayingMockCKDatabase {
     }
   }
   
-  struct FetchZoneChangesOperationResult: Codable {
+  struct FetchZoneChangesOperationResult: Codable, Sendable {
     let recordWasChangedInZoneResults: [RecordWasChangedInZoneResult]
     let recordWithIDWasDeletedInZoneResults: [RecordWithIDWasDeletedInZoneResult]
     let oneZoneFetchResults: [OneZoneFetchResult]

--- a/Targets/CanopyTestTools/Sources/ReplayingMockCKDatabase/ReplayingMockCKDatabase+FetchZones.swift
+++ b/Targets/CanopyTestTools/Sources/ReplayingMockCKDatabase/ReplayingMockCKDatabase+FetchZones.swift
@@ -2,7 +2,7 @@ import CanopyTypes
 import CloudKit
 
 public extension ReplayingMockCKDatabase {
-  struct FetchZoneResult: Codable {
+  struct FetchZoneResult: Codable, Sendable {
     public let zoneIDArchive: CloudKitRecordZoneIDArchive
     let codableResult: CodableResult<CloudKitRecordZoneArchive, CKRecordZoneError>
     
@@ -22,7 +22,7 @@ public extension ReplayingMockCKDatabase {
     }
   }
   
-  struct FetchZonesResult: Codable {
+  struct FetchZonesResult: Codable, Sendable {
     let codableResult: CodableResult<CodableVoid, CKRecordZoneError>
     
     public init(result: Result<Void, Error>) {
@@ -40,7 +40,7 @@ public extension ReplayingMockCKDatabase {
     }
   }
   
-  struct FetchZonesOperationResult: Codable {
+  struct FetchZonesOperationResult: Codable, Sendable {
     let fetchZoneResults: [FetchZoneResult]
     let fetchZonesResult: FetchZonesResult
     

--- a/Targets/CanopyTestTools/Sources/ReplayingMockCKDatabase/ReplayingMockCKDatabase+Modify.swift
+++ b/Targets/CanopyTestTools/Sources/ReplayingMockCKDatabase/ReplayingMockCKDatabase+Modify.swift
@@ -4,7 +4,7 @@ import CloudKit
 // Types and functionality for CKModifyRecordsOperation results.
 public extension ReplayingMockCKDatabase {
   /// Result for one saved record. perRecordSaveBlock is called with this.
-  struct SavedRecordResult: Codable {
+  struct SavedRecordResult: Codable, Sendable {
     let recordIDArchive: CloudKitRecordIDArchive
     let codableResult: CodableResult<CloudKitRecordArchive, CKRecordError>
     
@@ -25,7 +25,7 @@ public extension ReplayingMockCKDatabase {
   }
   
   /// Result for one deleted record. perRecordDeleteBlock is called with this.
-  struct DeletedRecordIDResult: Codable {
+  struct DeletedRecordIDResult: Codable, Sendable {
     let recordIDArchive: CloudKitRecordIDArchive
     let codableResult: CodableResult<CodableVoid, CKRecordError>
     
@@ -45,7 +45,7 @@ public extension ReplayingMockCKDatabase {
     }
   }
   
-  struct ModifyResult: Codable {
+  struct ModifyResult: Codable, Sendable {
     let codableResult: CodableResult<CodableVoid, CKRecordError>
     
     public init(result: Result<Void, Error>) {
@@ -63,7 +63,7 @@ public extension ReplayingMockCKDatabase {
     }
   }
   
-  struct ModifyOperationResult: Codable {
+  struct ModifyOperationResult: Codable, Sendable {
     let savedRecordResults: [SavedRecordResult]
     let deletedRecordIDResults: [DeletedRecordIDResult]
     let modifyResult: ModifyResult

--- a/Targets/CanopyTestTools/Sources/ReplayingMockCKDatabase/ReplayingMockCKDatabase+ModifySubscriptions.swift
+++ b/Targets/CanopyTestTools/Sources/ReplayingMockCKDatabase/ReplayingMockCKDatabase+ModifySubscriptions.swift
@@ -2,7 +2,7 @@ import CanopyTypes
 import CloudKit
 
 public extension ReplayingMockCKDatabase {
-  struct SavedSubscriptionResult: Codable {
+  struct SavedSubscriptionResult: Codable, Sendable {
     let subscriptionID: CKSubscription.ID
     let codableResult: CodableResult<CloudKitSubscriptionArchive, CKSubscriptionError>
     
@@ -22,7 +22,7 @@ public extension ReplayingMockCKDatabase {
     }
   }
   
-  struct DeletedSubscriptionIDResult: Codable {
+  struct DeletedSubscriptionIDResult: Codable, Sendable {
     let subscriptionID: CKSubscription.ID
     let codableResult: CodableResult<CodableVoid, CKSubscriptionError>
     
@@ -42,7 +42,7 @@ public extension ReplayingMockCKDatabase {
     }
   }
   
-  struct ModifySubscriptionsResult: Codable {
+  struct ModifySubscriptionsResult: Codable, Sendable {
     let codableResult: CodableResult<CodableVoid, CKSubscriptionError>
 
     public init(result: Result<Void, Error>) {
@@ -60,7 +60,7 @@ public extension ReplayingMockCKDatabase {
     }
   }
   
-  struct ModifySubscriptionsOperationResult: Codable {
+  struct ModifySubscriptionsOperationResult: Codable, Sendable {
     public let savedSubscriptionResults: [SavedSubscriptionResult]
     public let deletedSubscriptionIDResults: [DeletedSubscriptionIDResult]
     public let modifySubscriptionsResult: ModifySubscriptionsResult

--- a/Targets/CanopyTestTools/Sources/ReplayingMockCKDatabase/ReplayingMockCKDatabase+ModifyZones.swift
+++ b/Targets/CanopyTestTools/Sources/ReplayingMockCKDatabase/ReplayingMockCKDatabase+ModifyZones.swift
@@ -2,7 +2,7 @@ import CanopyTypes
 import CloudKit
 
 public extension ReplayingMockCKDatabase {
-  struct SavedZoneResult: Codable {
+  struct SavedZoneResult: Codable, Sendable {
     let zoneIDArchive: CloudKitRecordZoneIDArchive
     let codableResult: CodableResult<CloudKitRecordZoneArchive, CKRecordZoneError>
     
@@ -22,7 +22,7 @@ public extension ReplayingMockCKDatabase {
     }
   }
   
-  struct DeletedZoneIDResult: Codable {
+  struct DeletedZoneIDResult: Codable, Sendable {
     let zoneIDArchive: CloudKitRecordZoneIDArchive
     let codableResult: CodableResult<CodableVoid, CKRecordZoneError>
     
@@ -42,7 +42,7 @@ public extension ReplayingMockCKDatabase {
     }
   }
   
-  struct ModifyZonesResult: Codable {
+  struct ModifyZonesResult: Codable, Sendable {
     let codableResult: CodableResult<CodableVoid, CKRecordZoneError>
     
     public init(result: Result<Void, Error>) {
@@ -60,7 +60,7 @@ public extension ReplayingMockCKDatabase {
     }
   }
   
-  struct ModifyZonesOperationResult: Codable {
+  struct ModifyZonesOperationResult: Codable, Sendable {
     public let savedZoneResults: [SavedZoneResult]
     public let deletedZoneIDResults: [DeletedZoneIDResult]
     public let modifyZonesResult: ModifyZonesResult

--- a/Targets/CanopyTestTools/Sources/ReplayingMockCKDatabase/ReplayingMockCKDatabase+Query.swift
+++ b/Targets/CanopyTestTools/Sources/ReplayingMockCKDatabase/ReplayingMockCKDatabase+Query.swift
@@ -4,7 +4,7 @@ import CloudKit
 // Types and functionality for CKQueryOperation results.
 public extension ReplayingMockCKDatabase {
   /// Result for one record. recordMatchedBlock is called with this. Also used by ReplayingMockCKDatabase+Fetch.
-  struct QueryRecordResult: Codable {
+  struct QueryRecordResult: Codable, Sendable {
     let recordIDArchive: CloudKitRecordIDArchive
     let codableResult: CodableResult<CloudKitRecordArchive, CKRecordError>
     
@@ -29,7 +29,7 @@ public extension ReplayingMockCKDatabase {
   }
 
   /// Record for the whole query. queryResultBlock is called with this.
-  struct QueryResult: Codable {
+  struct QueryResult: Codable, Sendable {
     let codableResult: CodableResult<CloudKitCursorArchive?, CKRecordError>
     
     public init(result: Result<CKQueryOperation.Cursor?, Error>) {
@@ -54,7 +54,7 @@ public extension ReplayingMockCKDatabase {
     }
   }
   
-  struct QueryOperationResult: Codable {
+  struct QueryOperationResult: Codable, Sendable {
     public let queryRecordResults: [QueryRecordResult]
     public let queryResult: QueryResult
     

--- a/Targets/CanopyTestTools/Sources/ReplayingMockCKDatabase/ReplayingMockCKDatabase.swift
+++ b/Targets/CanopyTestTools/Sources/ReplayingMockCKDatabase/ReplayingMockCKDatabase.swift
@@ -10,7 +10,7 @@ public actor ReplayingMockCKDatabase {
   /// Whether to sleep in the operations where sleep has been enabled.
   let sleep: Float?
   
-  public enum OperationResult: Codable {
+  public enum OperationResult: Codable, Sendable {
     case modify(ModifyOperationResult)
     case query(QueryOperationResult)
     case fetch(FetchOperationResult)

--- a/Targets/CanopyTypes/Sources/Archiving/CloudKitCursorArchive.swift
+++ b/Targets/CanopyTypes/Sources/Archiving/CloudKitCursorArchive.swift
@@ -2,7 +2,7 @@ import CloudKit
 import Foundation
 
 /// Archive optionally containing a cursor.
-public struct CloudKitCursorArchive: Codable {
+public struct CloudKitCursorArchive: Codable, Sendable {
   private let data: Data
 
   public var cursor: CKQueryOperation.Cursor? {

--- a/Targets/CanopyTypes/Sources/Archiving/CloudKitLookupInfoArchive.swift
+++ b/Targets/CanopyTypes/Sources/Archiving/CloudKitLookupInfoArchive.swift
@@ -1,7 +1,7 @@
 import CloudKit
 import Foundation
 
-public struct CloudKitLookupInfoArchive: Codable {
+public struct CloudKitLookupInfoArchive: Codable, Sendable {
   private let data: Data
 
   public var lookupInfos: [CKUserIdentity.LookupInfo] {

--- a/Targets/CanopyTypes/Sources/Archiving/CloudKitRecordArchive.swift
+++ b/Targets/CanopyTypes/Sources/Archiving/CloudKitRecordArchive.swift
@@ -9,7 +9,7 @@
 import CloudKit
 import Foundation
 
-public struct CloudKitRecordArchive: Codable {
+public struct CloudKitRecordArchive: Codable, Sendable {
   private let data: Data
 
   public var records: [CKRecord] {

--- a/Targets/CanopyTypes/Sources/Archiving/CloudKitRecordIDArchive.swift
+++ b/Targets/CanopyTypes/Sources/Archiving/CloudKitRecordIDArchive.swift
@@ -9,7 +9,7 @@
 import CloudKit
 import Foundation
 
-public struct CloudKitRecordIDArchive: Codable {
+public struct CloudKitRecordIDArchive: Codable, Sendable {
   private let data: Data
 
   public var recordIDs: [CKRecord.ID] {

--- a/Targets/CanopyTypes/Sources/Archiving/CloudKitRecordZoneArchive.swift
+++ b/Targets/CanopyTypes/Sources/Archiving/CloudKitRecordZoneArchive.swift
@@ -1,7 +1,7 @@
 import CloudKit
 import Foundation
 
-public struct CloudKitRecordZoneArchive: Codable {
+public struct CloudKitRecordZoneArchive: Codable, Sendable {
   private let data: Data
 
   public var zones: [CKRecordZone] {

--- a/Targets/CanopyTypes/Sources/Archiving/CloudKitRecordZoneIDArchive.swift
+++ b/Targets/CanopyTypes/Sources/Archiving/CloudKitRecordZoneIDArchive.swift
@@ -9,7 +9,7 @@
 import CloudKit
 import Foundation
 
-public struct CloudKitRecordZoneIDArchive: Codable {
+public struct CloudKitRecordZoneIDArchive: Codable, Sendable {
   private let data: Data
 
   public var zoneIDs: [CKRecordZone.ID] {

--- a/Targets/CanopyTypes/Sources/Archiving/CloudKitServerChangeTokenArchive.swift
+++ b/Targets/CanopyTypes/Sources/Archiving/CloudKitServerChangeTokenArchive.swift
@@ -1,7 +1,7 @@
 import CloudKit
 import Foundation
 
-public struct CloudKitServerChangeTokenArchive: Codable {
+public struct CloudKitServerChangeTokenArchive: Codable, Sendable {
   private let data: Data
 
   public var token: CKServerChangeToken {

--- a/Targets/CanopyTypes/Sources/Archiving/CloudKitShareArchive.swift
+++ b/Targets/CanopyTypes/Sources/Archiving/CloudKitShareArchive.swift
@@ -9,7 +9,7 @@
 import CloudKit
 import Foundation
 
-public struct CloudKitShareArchive: Codable {
+public struct CloudKitShareArchive: Codable, Sendable {
   private let data: Data
 
   public var shares: [CKShare] {

--- a/Targets/CanopyTypes/Sources/Archiving/CloudKitShareMetadataArchive.swift
+++ b/Targets/CanopyTypes/Sources/Archiving/CloudKitShareMetadataArchive.swift
@@ -1,7 +1,7 @@
 import CloudKit
 import Foundation
 
-public struct CloudKitShareMetadataArchive: Codable {
+public struct CloudKitShareMetadataArchive: Codable, Sendable {
   private let data: Data
 
   public var shareMetadatas: [CKShare.Metadata] {

--- a/Targets/CanopyTypes/Sources/Archiving/CloudKitShareParticipantArchive.swift
+++ b/Targets/CanopyTypes/Sources/Archiving/CloudKitShareParticipantArchive.swift
@@ -9,7 +9,7 @@
 import CloudKit
 import Foundation
 
-public struct CloudKitShareParticipantArchive: Codable {
+public struct CloudKitShareParticipantArchive: Codable, Sendable {
   private let data: Data
 
   public var shareParticipants: [CKShare.Participant] {

--- a/Targets/CanopyTypes/Sources/Archiving/CloudKitSubscriptionArchive.swift
+++ b/Targets/CanopyTypes/Sources/Archiving/CloudKitSubscriptionArchive.swift
@@ -1,7 +1,7 @@
 import CloudKit
 import Foundation
 
-public struct CloudKitSubscriptionArchive: Codable {
+public struct CloudKitSubscriptionArchive: Codable, Sendable {
   private let data: Data
 
   public var subscription: CKSubscription {

--- a/Targets/CanopyTypes/Sources/CKContainerType.swift
+++ b/Targets/CanopyTypes/Sources/CKContainerType.swift
@@ -1,6 +1,6 @@
 import CloudKit
 
-public protocol CKContainerType {
+public protocol CKContainerType: Sendable {
   func fetchUserRecordID(completionHandler: @escaping @Sendable (CKRecord.ID?, Error?) -> Void)
   func accountStatus(completionHandler: @escaping @Sendable (CKAccountStatus, Error?) -> Void)
   func add(_ operation: CKOperation)

--- a/Targets/CanopyTypes/Sources/CKDatabaseType.swift
+++ b/Targets/CanopyTypes/Sources/CKDatabaseType.swift
@@ -1,5 +1,5 @@
 import CloudKit
 
-public protocol CKDatabaseType {
+public protocol CKDatabaseType: Sendable {
   func add(_ operation: CKDatabaseOperation)
 }

--- a/Targets/CanopyTypes/Sources/Errors/CKRecordError.swift
+++ b/Targets/CanopyTypes/Sources/Errors/CKRecordError.swift
@@ -13,7 +13,7 @@ import Foundation
 // Reason is that the partial errors dictionary will be using different keys for different operations
 // In this type, the keys are expected to be CKRecord.ID,
 
-public struct CKRecordError: CKTransactionError, Codable, Equatable {
+public struct CKRecordError: CKTransactionError, Codable, Equatable, Sendable {
   public let code: Int
   public let localizedDescription: String
   public let retryAfterSeconds: Double

--- a/Targets/CanopyTypes/Sources/Errors/CKRecordZoneError.swift
+++ b/Targets/CanopyTypes/Sources/Errors/CKRecordZoneError.swift
@@ -11,7 +11,7 @@ import Foundation
 
 // CKRecordZoneError for CKRecordZones.
 // In this type, the keys are expected to be CKRecord.ID,
-public struct CKRecordZoneError: CKTransactionError, Codable, Equatable {
+public struct CKRecordZoneError: CKTransactionError, Codable, Equatable, Sendable {
   public let code: Int
   public let localizedDescription: String
   public let retryAfterSeconds: Double

--- a/Targets/CanopyTypes/Sources/Errors/CKSubscriptionError.swift
+++ b/Targets/CanopyTypes/Sources/Errors/CKSubscriptionError.swift
@@ -11,7 +11,7 @@ import Foundation
 
 // CKSubscriptionError for CKSubscriptions.
 // In this type, the keys are expected to be CKSubscription.ID,
-public struct CKSubscriptionError: CKTransactionError, Codable, Equatable {
+public struct CKSubscriptionError: CKTransactionError, Codable, Equatable, Sendable {
   public let code: Int
   public let localizedDescription: String
   public let retryAfterSeconds: Double

--- a/Targets/CanopyTypes/Sources/Errors/CanopyError.swift
+++ b/Targets/CanopyTypes/Sources/Errors/CanopyError.swift
@@ -9,7 +9,7 @@
 import CloudKit
 import Foundation
 
-public enum CanopyError: Error, Codable, Equatable {
+public enum CanopyError: Error, Codable, Equatable, Sendable {
   case unknown
   case ckAccountError(String, Int) // description, code
   case ckSavedRecordsIsEmpty


### PR DESCRIPTION
I enabled strict concurrency checking for a bit, and annotated many Canopy types with Sendable and adjusted the API-s for better Swift concurrency conformance. Some public API had to slightly change.

This is done in preparation for smoother switching to Swift 6 language mode, which Canopy intends to do pretty soon.

Also specifies minimum platform requirements as iOS 16.4 and macOS 13.3, since that’s when many Sendable annotations showed up in CloudKit.