### PR TITLE
Xcode 16 warning fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,14 +4,14 @@ version: 2.1
 jobs:
   build:
     macos:
-      xcode: "15.4.0"
+      xcode: "16.0.0"
     steps:
       - checkout
       - run: swift build -v
 
   test:
     macos:
-      xcode: "15.4.0"
+      xcode: "16.0.0"
     steps:
       - checkout
       - run: swift test -v

--- a/Targets/Canopy/Tests/CanopyTests.swift
+++ b/Targets/Canopy/Tests/CanopyTests.swift
@@ -74,7 +74,9 @@ final class CanopyTests: XCTestCase {
     do {
       let _ = try await api.modifyRecords(saving: [changedRecord]).get()
     } catch {
-      XCTAssertTrue(error is CKRecordError)
+      XCTAssertNotNil(error)
+      // Error is CKRecordError, so we use a CKRecordError API to test it
+      XCTAssertEqual(error.batchErrors, [:])
     }
   }
   

--- a/Targets/Canopy/Tests/ContainerAPITests.swift
+++ b/Targets/Canopy/Tests/ContainerAPITests.swift
@@ -33,10 +33,8 @@ final class ContainerAPITests: XCTestCase {
     let containerAPI = CKContainerAPI(container: container, accountChangedSequence: .mock(elementsToProduce: 0))
     do {
       let _ = try await containerAPI.userRecordID.get()
-    } catch let recordError as CKRecordError {
-      XCTAssertEqual(recordError, CKRecordError(from: ckError))
     } catch {
-      XCTFail("Unexpected error: \(error)")
+      XCTAssertEqual(error, CKRecordError(from: ckError))
     }
   }
   
@@ -84,7 +82,7 @@ final class ContainerAPITests: XCTestCase {
     do {
       let _ = try await containerAPI.accountStatus.get()
     } catch {
-      XCTAssertEqual(error as! CanopyError, .ckAccountError("The operation couldn’t be completed. (CKErrorDomain error 36.)", CKError.Code.accountTemporarilyUnavailable.rawValue))
+      XCTAssertEqual(error, .ckAccountError("The operation couldn’t be completed. (CKErrorDomain error 36.)", CKError.Code.accountTemporarilyUnavailable.rawValue))
     }
   }
   
@@ -132,7 +130,7 @@ final class ContainerAPITests: XCTestCase {
     do {
       let _ = try await containerAPI.accountStatusStream.get()
     } catch {
-      XCTAssertEqual(error as! CKContainerAPIError, .onlyOneAccountStatusStreamSupported)
+      XCTAssertEqual(error, .onlyOneAccountStatusStreamSupported)
     }
     
     for await status in stream1 {
@@ -201,7 +199,7 @@ final class ContainerAPITests: XCTestCase {
     do {
       let _ = try await containerAPI.fetchShareParticipants(with: [lookupInfo1, lookupInfo2]).get()
     } catch {
-      XCTAssertEqual(error as! CKRecordError, CKRecordError(from: CKError(CKError.Code.badContainer)))
+      XCTAssertEqual(error, CKRecordError(from: CKError(CKError.Code.badContainer)))
     }
   }
   
@@ -233,7 +231,7 @@ final class ContainerAPITests: XCTestCase {
     do {
       let _ = try await containerAPI.fetchShareParticipants(with: [lookupInfo1, lookupInfo2]).get()
     } catch {
-      XCTAssertEqual(error as! CKRecordError, CKRecordError(from: CKError(CKError.Code.networkFailure)))
+      XCTAssertEqual(error, CKRecordError(from: CKError(CKError.Code.networkFailure)))
     }
   }
   
@@ -280,7 +278,7 @@ final class ContainerAPITests: XCTestCase {
     do {
       let _ = try await containerAPI.acceptShares(with: [CKShare.Metadata.mock, CKShare.Metadata.mock]).get()
     } catch {
-      XCTAssertEqual(error as! CKRecordError, CKRecordError(from: CKError(CKError.Code.networkUnavailable)))
+      XCTAssertEqual(error, CKRecordError(from: CKError(CKError.Code.networkUnavailable)))
     }
   }
   
@@ -305,7 +303,7 @@ final class ContainerAPITests: XCTestCase {
     do {
       let _ = try await containerAPI.acceptShares(with: [CKShare.Metadata.mock, CKShare.Metadata.mock]).get()
     } catch {
-      XCTAssertEqual(error as! CKRecordError, CKRecordError(from: CKError(CKError.Code.badContainer)))
+      XCTAssertEqual(error, CKRecordError(from: CKError(CKError.Code.badContainer)))
     }
   }
 }

--- a/Targets/Canopy/Tests/DatabaseAPITests.swift
+++ b/Targets/Canopy/Tests/DatabaseAPITests.swift
@@ -104,7 +104,7 @@ final class DatabaseAPITests: XCTestCase {
     do {
       let _ = try await api.deleteRecords(with: query, in: nil).get()
     } catch {
-      XCTAssertEqual(error as! CKRecordError, CKRecordError(from: CKError(CKError.Code.notAuthenticated)))
+      XCTAssertEqual(error, CKRecordError(from: CKError(CKError.Code.notAuthenticated)))
     }
   }
   
@@ -162,7 +162,7 @@ final class DatabaseAPITests: XCTestCase {
     do {
       let _ = try await api.fetchRecords(with: [recordID]).get()
     } catch {
-      XCTAssertEqual(error as! CKRecordError, CKRecordError(from: CKError(CKError.Code.notAuthenticated)))
+      XCTAssertEqual(error , CKRecordError(from: CKError(CKError.Code.notAuthenticated)))
     }
   }
   
@@ -183,7 +183,7 @@ final class DatabaseAPITests: XCTestCase {
     do {
       let _ = try await api.fetchRecords(with: [recordID]).get()
     } catch {
-      XCTAssertEqual(error as! CKRecordError, CKRecordError(from: CKError(CKError.Code.managedAccountRestricted)))
+      XCTAssertEqual(error , CKRecordError(from: CKError(CKError.Code.managedAccountRestricted)))
     }
   }
   
@@ -250,7 +250,7 @@ final class DatabaseAPITests: XCTestCase {
     do {
       let _ = try await api.modifyZones(saving: [zoneToSave], deleting: [zoneIDToDelete]).get()
     } catch {
-      XCTAssertEqual(error as! CKRecordZoneError, CKRecordZoneError(from: CKError(CKError.Code.networkUnavailable)))
+      XCTAssertEqual(error , CKRecordZoneError(from: CKError(CKError.Code.networkUnavailable)))
     }
   }
   
@@ -274,7 +274,7 @@ final class DatabaseAPITests: XCTestCase {
     do {
       let _ = try await api.modifyZones(saving: [zoneToSave], deleting: [zoneIDToDelete]).get()
     } catch {
-      XCTAssertEqual(error as! CKRecordZoneError, CKRecordZoneError(from: CKError(CKError.Code.accountTemporarilyUnavailable)))
+      XCTAssertEqual(error , CKRecordZoneError(from: CKError(CKError.Code.accountTemporarilyUnavailable)))
     }
   }
   
@@ -298,7 +298,7 @@ final class DatabaseAPITests: XCTestCase {
     do {
       let _ = try await api.modifyZones(saving: [zoneToSave], deleting: [zoneIDToDelete]).get()
     } catch {
-      XCTAssertEqual(error as! CKRecordZoneError, CKRecordZoneError(from: CKError(CKError.Code.invalidArguments)))
+      XCTAssertEqual(error , CKRecordZoneError(from: CKError(CKError.Code.invalidArguments)))
     }
   }
   
@@ -352,7 +352,7 @@ final class DatabaseAPITests: XCTestCase {
     do {
       let _ = try await api.fetchZones(with: [mockZone.zoneID]).get()
     } catch {
-      XCTAssertEqual(error as! CKRecordZoneError, CKRecordZoneError(from: CKError(CKError.Code.badDatabase)))
+      XCTAssertEqual(error , CKRecordZoneError(from: CKError(CKError.Code.badDatabase)))
     }
   }
   
@@ -372,7 +372,7 @@ final class DatabaseAPITests: XCTestCase {
     do {
       let _ = try await api.fetchZones(with: [mockZone.zoneID]).get()
     } catch {
-      XCTAssertEqual(error as! CKRecordZoneError, CKRecordZoneError(from: CKError(CKError.Code.zoneNotFound)))
+      XCTAssertEqual(error , CKRecordZoneError(from: CKError(CKError.Code.zoneNotFound)))
     }
   }
   
@@ -423,7 +423,7 @@ final class DatabaseAPITests: XCTestCase {
     do {
       let _ = try await api.modifySubscriptions(saving: [subscription]).get()
     } catch {
-      XCTAssertEqual(error as! CKSubscriptionError, CKSubscriptionError(from: CKError(CKError.Code.badDatabase)))
+      XCTAssertEqual(error , CKSubscriptionError(from: CKError(CKError.Code.badDatabase)))
     }
   }
   
@@ -450,7 +450,7 @@ final class DatabaseAPITests: XCTestCase {
     do {
       let _ = try await api.modifySubscriptions(saving: [subscription]).get()
     } catch {
-      XCTAssertEqual(error as! CKSubscriptionError, CKSubscriptionError(from: CKError(CKError.Code.badDatabase)))
+      XCTAssertEqual(error , CKSubscriptionError(from: CKError(CKError.Code.badDatabase)))
     }
   }
   
@@ -477,7 +477,7 @@ final class DatabaseAPITests: XCTestCase {
     do {
       let _ = try await api.modifySubscriptions(saving: [subscription]).get()
     } catch {
-      XCTAssertEqual(error as! CKSubscriptionError, CKSubscriptionError(from: CKError(CKError.Code.badDatabase)))
+      XCTAssertEqual(error , CKSubscriptionError(from: CKError(CKError.Code.badDatabase)))
     }
   }
 }

--- a/Targets/Canopy/Tests/FetchDatabaseChangesTests.swift
+++ b/Targets/Canopy/Tests/FetchDatabaseChangesTests.swift
@@ -54,7 +54,7 @@ final class FetchDatabaseChangesTests: XCTestCase {
     do {
       let _ = try await api.fetchDatabaseChanges().get()
     } catch {
-      XCTAssertEqual(error as! CanopyError, CanopyError.ckChangeTokenExpired)
+      XCTAssertEqual(error, CanopyError.ckChangeTokenExpired)
       let storeTokenForDatabaseScopeCalls = await testTokenStore.storeTokenForDatabaseScopeCalls
       XCTAssertEqual(storeTokenForDatabaseScopeCalls, 1) // nil token was stored
     }
@@ -76,7 +76,7 @@ final class FetchDatabaseChangesTests: XCTestCase {
     do {
       let _ = try await api.fetchDatabaseChanges().get()
     } catch {
-      XCTAssertEqual(error as! CanopyError, CanopyError.ckRequestError(CKRequestError(from: CKError(CKError.Code.networkFailure))))
+      XCTAssertEqual(error, CanopyError.ckRequestError(CKRequestError(from: CKError(CKError.Code.networkFailure))))
       let storeTokenForDatabaseScopeCalls = await testTokenStore.storeTokenForDatabaseScopeCalls
       XCTAssertEqual(storeTokenForDatabaseScopeCalls, 0) // nothing should have been stored
     }
@@ -139,7 +139,7 @@ final class FetchDatabaseChangesTests: XCTestCase {
     do {
       let _ = try await api.fetchDatabaseChanges().get()
     } catch {
-      switch error as! CanopyError {
+      switch error {
       case .ckRequestError:
         break
       default:
@@ -177,7 +177,7 @@ final class FetchDatabaseChangesTests: XCTestCase {
     do {
       let _ = try await api.fetchDatabaseChanges().get()
     } catch {
-      switch error as! CanopyError {
+      switch error {
       case .ckRequestError:
         break
       default:

--- a/Targets/Canopy/Tests/FetchZoneChangesTests.swift
+++ b/Targets/Canopy/Tests/FetchZoneChangesTests.swift
@@ -170,7 +170,7 @@ final class FetchZoneChangesTests: XCTestCase {
       XCTAssertEqual(getTokenForRecordZoneCalls, 2)
       // Stored only one nil token
       XCTAssertEqual(storeTokenForRecordZoneCalls, 1)
-      XCTAssertEqual(error as! CanopyError, .ckRecordZoneError(.init(from: CKError(CKError.Code.changeTokenExpired))))
+      XCTAssertEqual(error, .ckRecordZoneError(.init(from: CKError(CKError.Code.changeTokenExpired))))
     }
   }
   
@@ -211,7 +211,7 @@ final class FetchZoneChangesTests: XCTestCase {
       XCTAssertEqual(getTokenForRecordZoneCalls, 1)
       XCTAssertEqual(storeTokenForRecordZoneCalls, 0)
       
-      XCTAssertEqual(error as! CanopyError, .ckRequestError(.init(from: CKError(CKError.Code.accountTemporarilyUnavailable))))
+      XCTAssertEqual(error, .ckRequestError(.init(from: CKError(CKError.Code.accountTemporarilyUnavailable))))
     }
   }
   
@@ -290,7 +290,7 @@ final class FetchZoneChangesTests: XCTestCase {
         fetchMethod: .changeTokenAndAllData
       ).get()
     } catch {
-      switch error as! CanopyError {
+      switch error {
       case .ckRequestError:
         break
       default:
@@ -338,7 +338,7 @@ final class FetchZoneChangesTests: XCTestCase {
         fetchMethod: .changeTokenAndAllData
       ).get()
     } catch {
-      switch error as! CanopyError {
+      switch error {
       case .ckRequestError:
         break
       default:

--- a/Targets/Canopy/Tests/ModifyRecordsFeatureTests.swift
+++ b/Targets/Canopy/Tests/ModifyRecordsFeatureTests.swift
@@ -39,10 +39,8 @@ final class ModifyRecordsFeatureTests: XCTestCase {
         database: db,
         qualityOfService: .default
       ).get()
-    } catch let recordError as CKRecordError {
+    } catch let recordError {
       XCTAssertEqual(recordError, CKRecordError(from: CKError(CKError.Code.internalError)))
-    } catch {
-      XCTFail("Unexpected error: \(error)")
     }
   }
   
@@ -270,7 +268,7 @@ final class ModifyRecordsFeatureTests: XCTestCase {
       // Second get gets the operation result, and this will throw because the operation resulted with error.
       let _ = try await task.result.get().get()
     } catch {
-      XCTAssertEqual(error as! CKRecordError, CKRecordError(from: CKError(CKError.Code.operationCancelled)))
+      XCTAssertEqual(error, CKRecordError(from: CKError(CKError.Code.operationCancelled)))
     }
     
     let operationsRun = await db.operationsRun
@@ -305,7 +303,7 @@ final class ModifyRecordsFeatureTests: XCTestCase {
         qualityOfService: .default
       ).get()
     } catch {
-      XCTAssertEqual(error as! CKRecordError, CKRecordError(from: CKError(CKError.Code.internalError)))
+      XCTAssertEqual(error, CKRecordError(from: CKError(CKError.Code.internalError)))
     }
     
     let operationsRun = await db.operationsRun
@@ -339,7 +337,7 @@ final class ModifyRecordsFeatureTests: XCTestCase {
         qualityOfService: .default
       ).get()
     } catch {
-      XCTAssertEqual(error as! CKRecordError, CKRecordError(from: CKError(CKError.Code.internalError)))
+      XCTAssertEqual(error, CKRecordError(from: CKError(CKError.Code.internalError)))
     }
 
     let operationsRun = await db.operationsRun
@@ -374,7 +372,7 @@ final class ModifyRecordsFeatureTests: XCTestCase {
         qualityOfService: .default
       ).get()
     } catch {
-      XCTAssertEqual(error as! CKRecordError, CKRecordError(from: CKError(CKError.Code.networkFailure)))
+      XCTAssertEqual(error, CKRecordError(from: CKError(CKError.Code.networkFailure)))
     }
     
     let operationsRun = await db.operationsRun
@@ -473,7 +471,7 @@ final class ModifyRecordsFeatureTests: XCTestCase {
         autoBatchToSmallerWhenLimitExceeded: false
       ).get()
     } catch {
-      XCTAssertEqual(error as! CKRecordError, CKRecordError(from: CKError(CKError.Code.limitExceeded)))
+      XCTAssertEqual(error, CKRecordError(from: CKError(CKError.Code.limitExceeded)))
       let operationsRun = await db.operationsRun
       XCTAssertEqual(operationsRun, 1)
     }
@@ -581,7 +579,7 @@ final class ModifyRecordsFeatureTests: XCTestCase {
         autoRetryForRetriableErrors: true
       ).get()
     } catch {
-      XCTAssertTrue((error as! CKRecordError).code == CKError.Code.zoneBusy.rawValue)
+      XCTAssertTrue(error.code == CKError.Code.zoneBusy.rawValue)
       let operationsRun = await db.operationsRun
       XCTAssertEqual(operationsRun, 3)
     }

--- a/Targets/Canopy/Tests/ModifyRecordsTests.swift
+++ b/Targets/Canopy/Tests/ModifyRecordsTests.swift
@@ -110,7 +110,8 @@ final class ModifyRecordsTests: XCTestCase {
     do {
       let _ = try await api.modifyRecords(saving: [record]).get()
     } catch {
-      XCTAssertTrue(error is CKRecordError)
+      XCTAssertNotNil(error)
+      XCTAssertEqual(error.batchErrors, [:])
     }
   }
   
@@ -138,7 +139,8 @@ final class ModifyRecordsTests: XCTestCase {
     do {
       let _ = try await api.modifyRecords(saving: [record]).get()
     } catch {
-      XCTAssertTrue(error is CKRecordError)
+      XCTAssertNotNil(error)
+      XCTAssertEqual(error.batchErrors, [:])
     }
   }
   
@@ -175,9 +177,7 @@ final class ModifyRecordsTests: XCTestCase {
         deleting: [recordIDToDelete]
       ).get()
     } catch {
-      XCTAssertTrue(error is CKRecordError)
-      let ckRecordError = error as! CKRecordError
-      XCTAssertEqual(ckRecordError.batchErrors.count, 2)
+      XCTAssertEqual(error.batchErrors.count, 2)
     }
   }
   
@@ -260,7 +260,7 @@ final class ModifyRecordsTests: XCTestCase {
         deleting: [recordIDToDelete]
       ).get()
     } catch {
-      XCTAssertEqual(error as! CKRecordError, CKRecordError(from: CKError(CKError.Code.limitExceeded)))
+      XCTAssertEqual(error, CKRecordError(from: CKError(CKError.Code.limitExceeded)))
       let operationsRun = await db.operationsRun
       XCTAssertEqual(operationsRun, 1)
     }
@@ -321,7 +321,7 @@ final class ModifyRecordsTests: XCTestCase {
         deleting: []
       ).get()
     } catch {
-      XCTAssertEqual(error as! CKRecordError, CKRecordError(from: CKError(CKError.Code.zoneBusy, userInfo: [CKErrorRetryAfterKey: 0.2])))
+      XCTAssertEqual(error, CKRecordError(from: CKError(CKError.Code.zoneBusy, userInfo: [CKErrorRetryAfterKey: 0.2])))
       let operationsRun = await db.operationsRun
       XCTAssertEqual(operationsRun, 1)
     }

--- a/Targets/Canopy/Tests/QueryRecordsFeatureTests.swift
+++ b/Targets/Canopy/Tests/QueryRecordsFeatureTests.swift
@@ -180,10 +180,8 @@ final class QueryRecordsFeatureTests: XCTestCase {
     
     do {
       let _ = try await task.result.get().get()
-    } catch let recordError as CKRecordError {
+    } catch let recordError {
       XCTAssertEqual(recordError, .init(from: CKError(CKError.Code.operationCancelled)))
-    } catch {
-      XCTFail("Unexpected error: \(error)")
     }
     
     let operationsRun = await db.operationsRun
@@ -212,7 +210,7 @@ final class QueryRecordsFeatureTests: XCTestCase {
         database: db
       ).get()
     } catch {
-      XCTAssertEqual(error as! CKRecordError, CKRecordError(from: CKError(CKError.Code.requestRateLimited)))
+      XCTAssertEqual(error, CKRecordError(from: CKError(CKError.Code.requestRateLimited)))
     }
   }
   
@@ -246,7 +244,7 @@ final class QueryRecordsFeatureTests: XCTestCase {
         database: db
       ).get()
     } catch {
-      XCTAssertEqual(error as! CKRecordError, CKRecordError(from: CKError(CKError.Code.networkFailure)))
+      XCTAssertEqual(error, CKRecordError(from: CKError(CKError.Code.networkFailure)))
     }
   }
 }

--- a/Targets/Canopy/Tests/ReplayingMockContainerTests.swift
+++ b/Targets/Canopy/Tests/ReplayingMockContainerTests.swift
@@ -33,7 +33,7 @@ final class ReplayingMockContainerTests: XCTestCase {
     do {
       let _ = try await mockContainer.userRecordID.get()
     } catch {
-      XCTAssertEqual(error as! CKRecordError, CKRecordError(from: CKError(CKError.Code.networkFailure)))
+      XCTAssertEqual(error, CKRecordError(from: CKError(CKError.Code.networkFailure)))
     }
   }
   
@@ -63,7 +63,7 @@ final class ReplayingMockContainerTests: XCTestCase {
     do {
       let _ = try await mockContainer.accountStatus.get()
     } catch {
-      XCTAssertEqual((error as! CanopyError).code, CKError.Code.badContainer.rawValue)
+      XCTAssertEqual(error.code, CKError.Code.badContainer.rawValue)
     }
   }
   
@@ -91,7 +91,7 @@ final class ReplayingMockContainerTests: XCTestCase {
     do {
       let _ = try await mockContainer.accountStatusStream.get()
     } catch {
-      XCTAssertEqual((error as! CKContainerAPIError), .onlyOneAccountStatusStreamSupported)
+      XCTAssertEqual(error, .onlyOneAccountStatusStreamSupported)
     }
   }
   
@@ -114,7 +114,7 @@ final class ReplayingMockContainerTests: XCTestCase {
     do {
       let _ = try await mockContainer.acceptShares(with: []).get()
     } catch {
-      XCTAssertEqual((error as! CKRecordError).code, CKError.Code.networkFailure.rawValue)
+      XCTAssertEqual(error.code, CKError.Code.networkFailure.rawValue)
     }
   }
   
@@ -137,7 +137,7 @@ final class ReplayingMockContainerTests: XCTestCase {
     do {
       let _ = try await mockContainer.fetchShareParticipants(with: []).get()
     } catch {
-      XCTAssertEqual((error as! CKRecordError).code, CKError.Code.networkFailure.rawValue)
+      XCTAssertEqual(error.code, CKError.Code.networkFailure.rawValue)
     }
   }
 }

--- a/Targets/Canopy/Tests/ReplayingMockDatabaseTests.swift
+++ b/Targets/Canopy/Tests/ReplayingMockDatabaseTests.swift
@@ -24,10 +24,8 @@ final class ReplayingMockDatabaseTests: XCTestCase {
     ])
     do {
       let _ = try await db.queryRecords(with: .init(recordType: "MockType", predicate: NSPredicate(value: true)), in: nil).get()
-    } catch let recordError as CKRecordError {
+    } catch let recordError {
       XCTAssertEqual(recordError, CKRecordError(from: CKError(CKError.Code.badDatabase)))
-    } catch {
-      XCTFail("Unexpected error: \(error)")
     }
   }
   
@@ -64,10 +62,8 @@ final class ReplayingMockDatabaseTests: XCTestCase {
     ])
     do {
       let _ = try await db.modifyRecords(saving: [], deleting: []).get()
-    } catch let recordError as CKRecordError {
+    } catch let recordError {
       XCTAssertEqual(recordError, CKRecordError(from: CKError(CKError.Code.networkFailure)))
-    } catch {
-      XCTFail("Unexpected error: \(error)")
     }
   }
   
@@ -98,10 +94,8 @@ final class ReplayingMockDatabaseTests: XCTestCase {
     ])
     do {
       let _ = try await db.deleteRecords(with: CKQuery(recordType: "SomeType", predicate: NSPredicate(value: true)), in: nil).get()
-    } catch let recordError as CKRecordError {
+    } catch let recordError {
       XCTAssertEqual(recordError, CKRecordError(from: CKError(CKError.Code.networkFailure)))
-    } catch {
-      XCTFail("Unexpected error: \(error)")
     }
   }
   
@@ -139,10 +133,8 @@ final class ReplayingMockDatabaseTests: XCTestCase {
     ])
     do {
       let _ = try await db.fetchRecords(with: []).get()
-    } catch let recordError as CKRecordError {
+    } catch let recordError {
       XCTAssertEqual(recordError, CKRecordError(from: CKError(CKError.Code.networkFailure)))
-    } catch {
-      XCTFail("Unexpected error: \(error)")
     }
   }
   
@@ -174,10 +166,8 @@ final class ReplayingMockDatabaseTests: XCTestCase {
     ])
     do {
       let _ = try await db.modifyZones(saving: [], deleting: []).get()
-    } catch let recordError as CKRecordZoneError {
+    } catch let recordError {
       XCTAssertEqual(recordError, CKRecordZoneError(from: CKError(CKError.Code.badDatabase)))
-    } catch {
-      XCTFail("Unexpected error: \(error)")
     }
   }
   
@@ -203,10 +193,8 @@ final class ReplayingMockDatabaseTests: XCTestCase {
     ])
     do {
       let _ = try await db.fetchZones(with: []).get()
-    } catch let recordError as CKRecordZoneError {
+    } catch let recordError {
       XCTAssertEqual(recordError, CKRecordZoneError(from: CKError(CKError.Code.badDatabase)))
-    } catch {
-      XCTFail("Unexpected error: \(error)")
     }
   }
   
@@ -232,10 +220,8 @@ final class ReplayingMockDatabaseTests: XCTestCase {
     ])
     do {
       let _ = try await db.fetchAllZones().get()
-    } catch let recordError as CKRecordZoneError {
+    } catch let recordError {
       XCTAssertEqual(recordError, CKRecordZoneError(from: CKError(CKError.Code.badDatabase)))
-    } catch {
-      XCTFail("Unexpected error: \(error)")
     }
   }
   
@@ -270,10 +256,8 @@ final class ReplayingMockDatabaseTests: XCTestCase {
     ])
     do {
       let _ = try await db.modifySubscriptions(saving: [], deleting: []).get()
-    } catch let recordError as CKSubscriptionError {
+    } catch let recordError {
       XCTAssertEqual(recordError, CKSubscriptionError(from: CKError(CKError.Code.badDatabase)))
-    } catch {
-      XCTFail("Unexpected error: \(error)")
     }
   }
   


### PR DESCRIPTION
Fixes compilation warnings in Xcode 16. Now builds cleanly with Xcode 16 (using Swift tools 5.10, not yet opting in to Swift 6 language mode).